### PR TITLE
Fix Cleric Ancestral Domain ancestry point calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,3 @@
 
 ### Character Creation & Validation
 - **Fix skill and trade caps validation**: Implement proper validation for skill and trade point spending limits during character creation to prevent overspending.
-- **Fix ancestry point calculation for Cleric domain ancestry**: The Cleric's "Ancestral" domain grants +2 ancestry points, but this bonus is not being properly calculated and applied during character creation. Need to ensure domain choice benefits are reflected in available ancestry points.

--- a/src/lib/services/characterCalculator.ts
+++ b/src/lib/services/characterCalculator.ts
@@ -165,6 +165,9 @@ export const calculateCharacterStats = async (
 	const classData = characterData.classId ? await getClassData(characterData.classId) : null;
 	console.log('Class data loaded:', classData);
 
+	// Get class features data
+	const classFeatures = classData ? findClassByName(classData.name) : null;
+
 	// Get ancestry data
 	const ancestry1Data = getAncestryData(characterData.ancestry1Id);
 	const ancestry2Data = getAncestryData(characterData.ancestry2Id);
@@ -218,7 +221,6 @@ export const calculateCharacterStats = async (
 		finalInitiativeBonus = classData.initiativeBonusBase;
 
 		// Apply effects from class features using the new class features structure
-		const classFeatures = findClassByName(classData.name);
 		if (classFeatures) {
 			// Get level 1 features
 			const level1Features = classFeatures.coreFeatures.filter(

--- a/src/lib/stores/characterContext.tsx
+++ b/src/lib/stores/characterContext.tsx
@@ -146,6 +146,7 @@ interface CharacterContextType {
 	attributePointsRemaining: number;
 	ancestryPointsRemaining: number;
 	ancestryPointsSpent: number;
+	totalAncestryPoints: number;
 	combatMastery: number;
 	primeModifier: { name: string; value: number };
 }
@@ -283,6 +284,7 @@ export function CharacterProvider({ children }: { children: ReactNode }) {
 		attributePointsRemaining,
 		ancestryPointsRemaining,
 		ancestryPointsSpent,
+		totalAncestryPoints,
 		combatMastery,
 		primeModifier
 	};

--- a/src/routes/character-creation/SelectedAncestries.tsx
+++ b/src/routes/character-creation/SelectedAncestries.tsx
@@ -17,7 +17,7 @@ import {
 } from './styles/SelectedAncestries.styles';
 
 function SelectedAncestries() {
-	const { state, dispatch, ancestryPointsRemaining, ancestryPointsSpent } = useCharacter();
+	const { state, dispatch, ancestryPointsRemaining, ancestryPointsSpent, totalAncestryPoints } = useCharacter();
 
 	const selectedAncestry1 = ancestriesData.find((a) => a.id === state.ancestry1Id);
 	const selectedAncestry2 = ancestriesData.find((a) => a.id === state.ancestry2Id);
@@ -40,7 +40,7 @@ function SelectedAncestries() {
 		} else {
 			// Select - check if we have enough points
 			const newPointsSpent = ancestryPointsSpent + trait.cost;
-			if (newPointsSpent > 5) {
+			if (newPointsSpent > totalAncestryPoints) {
 				// Would exceed budget, don't allow selection
 				return;
 			}
@@ -61,7 +61,7 @@ function SelectedAncestries() {
 						const trait = getTrait(traitId);
 						if (!trait) return null;
 						const isSelected = selectedTraits.includes(traitId);
-						const wouldExceedBudget = !isSelected && ancestryPointsSpent + trait.cost > 5;
+						const wouldExceedBudget = !isSelected && ancestryPointsSpent + trait.cost > totalAncestryPoints;
 
 						return (
 							<StyledListItem key={traitId}>
@@ -88,7 +88,7 @@ function SelectedAncestries() {
 						const trait = getTrait(traitId);
 						if (!trait) return null;
 						const isSelected = selectedTraits.includes(traitId);
-						const wouldExceedBudget = !isSelected && ancestryPointsSpent + trait.cost > 5;
+						const wouldExceedBudget = !isSelected && ancestryPointsSpent + trait.cost > totalAncestryPoints;
 
 						return (
 							<StyledListItem key={traitId}>


### PR DESCRIPTION
- Updated characterContext.tsx to expose totalAncestryPoints in context interface
- Fixed SelectedAncestries.tsx to use dynamic totalAncestryPoints instead of hardcoded 5
- Fixed characterCalculator.ts scope issue with classFeatures variable
- Verified regex pattern correctly matches both 'get' and 'gain' ancestry point descriptions
- Cleric with Ancestral Domain now correctly has 7 total ancestry points (5 base + 2 bonus)
- Updated README.md to remove completed TODO item

Resolves the issue where Cleric's Ancestral Domain was not properly granting +2 ancestry points during character creation.