### PR TITLE
fix: resolve critical TypeScript errors in class features

### DIFF
--- a/src/lib/rulesdata/classes-data/features/barbarian_features.ts
+++ b/src/lib/rulesdata/classes-data/features/barbarian_features.ts
@@ -19,7 +19,8 @@ export const barbarianClass: ClassDefinition = {
 			maximumIncreasesBy: 'Stamina Points column of the Barbarian Class Table'
 		},
 		staminaRegen: {
-			description: 'Once per round, you can regain up to half your maximum SP when you score a Heavy or Critical Hit against a creature, or when a Heavy or Critical Hit is scored against you.',
+			description:
+				'Once per round, you can regain up to half your maximum SP when you score a Heavy or Critical Hit against a creature, or when a Heavy or Critical Hit is scored against you.'
 		}
 	},
 	coreFeatures: [
@@ -31,7 +32,7 @@ export const barbarianClass: ClassDefinition = {
 				{ type: 'GRANT_COMBAT_TRAINING', target: 'Weapons', value: true },
 				{ type: 'GRANT_COMBAT_TRAINING', target: 'All_Armor', value: true },
 				{ type: 'GRANT_COMBAT_TRAINING', target: 'All_Shields', value: true },
-				{ type: 'GRANT_MANEUVERS', target: 'all_attack', value: true }
+				{ type: 'GRANT_MANEUVERS', target: 'all_attack', value: 4 }
 			],
 			benefits: [
 				{
@@ -47,7 +48,7 @@ export const barbarianClass: ClassDefinition = {
 					name: 'Maneuver Knowledge',
 					description:
 						'You learn all Attack maneuvers plus additional maneuvers as shown on the Barbarian Class Table.',
-					effects: [{ type: 'GRANT_MANEUVERS', target: 'all_attack', value: true }]
+					effects: [{ type: 'GRANT_MANEUVERS', target: 'all_attack', value: 4 }]
 				},
 				{
 					name: 'Stamina Regeneration',
@@ -344,7 +345,7 @@ export const barbarianClass: ClassDefinition = {
 					description: 'Bestowed Protection and Spiritual Aura while Raging.',
 					effects: [
 						{ type: 'GRANT_CHOICE', target: 'guardian_maneuver', value: 1 },
-						{ type: 'GRANT_RESISTANCE', target: 'Mystical', value: 1, condition: 'raging' },
+						{ type: 'GRANT_RESISTANCE', target: 'Mystical', value: 1, optional: 'while raging' },
 						{
 							type: 'GRANT_ABILITY',
 							target: 'spiritual_aura',
@@ -361,17 +362,17 @@ export const barbarianClass: ClassDefinition = {
 								{
 									name: 'Parry',
 									description: 'Learn the Parry maneuver.',
-									effects: [{ type: 'GRANT_CHOICE', target: 'maneuver', value: 'Parry' }]
+									effects: [{ type: 'GRANT_MANEUVERS', target: 'Parry', value: 1 }]
 								},
 								{
 									name: 'Protect',
 									description: 'Learn the Protect maneuver.',
-									effects: [{ type: 'GRANT_CHOICE', target: 'maneuver', value: 'Protect' }]
+									effects: [{ type: 'GRANT_MANEUVERS', target: 'Protect', value: 1 }]
 								},
 								{
 									name: 'Raise Shield',
 									description: 'Learn the Raise Shield maneuver.',
-									effects: [{ type: 'GRANT_CHOICE', target: 'maneuver', value: 'Raise Shield' }]
+									effects: [{ type: 'GRANT_MANEUVERS', target: 'Raise Shield', value: 1 }]
 								}
 							]
 						}

--- a/src/lib/rulesdata/classes-data/features/champion_features.ts
+++ b/src/lib/rulesdata/classes-data/features/champion_features.ts
@@ -24,7 +24,8 @@ export const championClass: ClassDefinition = {
 			maximumIncreasesBy: 'Stamina Points column of the Champion Class Table'
 		},
 		staminaRegen: {
-			description: 'Once per round, you can regain up to half your maximum SP when you perform a Maneuver.',
+			description:
+				'Once per round, you can regain up to half your maximum SP when you perform a Maneuver.'
 		}
 	},
 	coreFeatures: [

--- a/src/lib/rulesdata/classes-data/features/commander_features.ts
+++ b/src/lib/rulesdata/classes-data/features/commander_features.ts
@@ -24,7 +24,8 @@ export const commanderClass: ClassDefinition = {
 			maximumIncreasesBy: 'Stamina Points column of the Commander Class Table'
 		},
 		staminaRegen: {
-			description: 'Once per round, regain up to half maximum SP when you grant a creature a Help Die.',
+			description:
+				'Once per round, regain up to half maximum SP when you grant a creature a Help Die.'
 		}
 	},
 	coreFeatures: [
@@ -36,7 +37,7 @@ export const commanderClass: ClassDefinition = {
 				{ type: 'GRANT_COMBAT_TRAINING', target: 'Weapons', value: true },
 				{ type: 'GRANT_COMBAT_TRAINING', target: 'All_Armor', value: true },
 				{ type: 'GRANT_COMBAT_TRAINING', target: 'All_Shields', value: true },
-				{ type: 'GRANT_MANEUVERS', target: 'all_attack', value: true }
+				{ type: 'GRANT_MANEUVERS', target: 'all_attack', value: 4 }
 			],
 			benefits: [
 				{

--- a/src/lib/rulesdata/classes-data/features/hunter_features.ts
+++ b/src/lib/rulesdata/classes-data/features/hunter_features.ts
@@ -24,7 +24,8 @@ export const hunterClass: ClassDefinition = {
 			maximumIncreasesBy: 'Stamina Points column of the Hunter Class Table'
 		},
 		staminaRegen: {
-			description: 'Once per round, you can regain up to half your maximum SP when you score a Heavy or Critical Hit.',
+			description:
+				'Once per round, you can regain up to half your maximum SP when you score a Heavy or Critical Hit.'
 		}
 	},
 	coreFeatures: [

--- a/src/lib/rulesdata/classes-data/features/monk_features.ts
+++ b/src/lib/rulesdata/classes-data/features/monk_features.ts
@@ -30,7 +30,6 @@ export const monkClass: ClassDefinition = {
 	},
 	coreFeatures: [
 		{
-			id: 'monk_training',
 			featureName: 'Monk Training',
 			levelGained: 1,
 			description: 'Your martial arts training grants you greater offense, defense, and movement.',
@@ -103,18 +102,5 @@ export const monkClass: ClassDefinition = {
 				}
 			]
 		},
-		{
-			id: 'mastery_progression',
-			featureName: 'Mastery Progression',
-			levelGained: 1,
-			description: 'You gain Combat Mastery progression as shown on the class table.',
-			effects: [
-				{
-					type: 'MODIFY_STAT',
-					target: 'combatMastery',
-					value: 'level_based'
-				}
-			]
-		}
 	]
 };

--- a/src/lib/rulesdata/classes-data/features/psion_features.ts
+++ b/src/lib/rulesdata/classes-data/features/psion_features.ts
@@ -23,12 +23,14 @@ export const psionClass: ClassDefinition = {
 				maximumIncreasesBy: 'Stamina Points column of the Psion Class Table'
 			},
 			staminaRegen: {
-				description: 'Once per round, you can regain up to half your maximum SP when you succeed on a spell attack.',
+				description:
+					'Once per round, you can regain up to half your maximum SP when you succeed on a spell attack.'
 			}
 		},
 		spellcastingAspect: {
 			spellList: {
-				description: 'Psychic or Gravity Spell Tags plus Divination, Enchantment, Illusion, Protection schools',
+				description:
+					'Psychic or Gravity Spell Tags plus Divination, Enchantment, Illusion, Protection schools',
 				type: 'specific'
 			},
 			cantrips: {
@@ -46,49 +48,58 @@ export const psionClass: ClassDefinition = {
 		{
 			featureName: 'Psion Spellcasting',
 			levelGained: 1,
-			description: 'You can cast spells from the Psychic or Gravity tags and the schools of Divination, Enchantment, Illusion, or Protection. Your combat masteries include Weapons, Light Armor, and Spellcasting. Your Cantrips Known, Spells Known, Mana Points, and Stamina Points advance as per the Psion class table.'
+			description:
+				'You can cast spells from the Psychic or Gravity tags and the schools of Divination, Enchantment, Illusion, or Protection. Your combat masteries include Weapons, Light Armor, and Spellcasting. Your Cantrips Known, Spells Known, Mana Points, and Stamina Points advance as per the Psion class table.'
 		},
 		{
 			featureName: 'Psion Stamina',
 			levelGained: 1,
-			description: 'Once per round, if you take a turn in combat without expending SP you regain 1 SP.'
+			description:
+				'Once per round, if you take a turn in combat without expending SP you regain 1 SP.'
 		},
 		{
 			featureName: 'Psionic Mind',
 			levelGained: 1,
-			description: 'You learn the Psi Bolt cantrip, your MD increases by 2, you can spend SP on AP enhancements, and you gain the Daze and Disruption spell enhancements as well as the Psionic enhancement (1 MP) removing verbal and somatic components.'
+			description:
+				'You learn the Psi Bolt cantrip, your MD increases by 2, you can spend SP on AP enhancements, and you gain the Daze and Disruption spell enhancements as well as the Psionic enhancement (1 MP) removing verbal and somatic components.'
 		},
 		{
 			featureName: 'Telekinesis',
 			levelGained: 1,
-			description: 'You can use the Object action to manipulate objects up to 100 lbs within 5 spaces via telekinesis.'
+			description:
+				'You can use the Object action to manipulate objects up to 100 lbs within 5 spaces via telekinesis.'
 		},
 		{
 			featureName: 'Telekinetic Grapple',
 			levelGained: 1,
-			description: 'You gain Grapple maneuvers which you perform with telekinesis. You may target creatures within 5 spaces and use Spell Checks instead of Might for related checks. Additional rules modify Body Block, Grapple, Shove, and Throw.'
+			description:
+				'You gain Grapple maneuvers which you perform with telekinesis. You may target creatures within 5 spaces and use Spell Checks instead of Might for related checks. Additional rules modify Body Block, Grapple, Shove, and Throw.'
 		},
 		{
 			featureName: 'Telepathy',
 			levelGained: 1,
 			isFlavor: true,
-			description: 'You can communicate telepathically with any creature you can see within 10 spaces that knows at least one language.'
+			description:
+				'You can communicate telepathically with any creature you can see within 10 spaces that knows at least one language.'
 		},
 		// Level 2 Features
 		{
 			featureName: 'Mind Sense',
 			levelGained: 2,
-			description: 'Spend 1 AP and 1 MP to sense creatures within 10 spaces (Int ≥ -3) for 1 minute.'
+			description:
+				'Spend 1 AP and 1 MP to sense creatures within 10 spaces (Int ≥ -3) for 1 minute.'
 		},
 		{
 			featureName: 'Invade Mind',
 			levelGained: 2,
-			description: 'While Mind Sense is active, spend 1 AP and 1 SP to Assault Mind, Read Emotions, or Read Thoughts of a sensed creature within 10 spaces.'
+			description:
+				'While Mind Sense is active, spend 1 AP and 1 SP to Assault Mind, Read Emotions, or Read Thoughts of a sensed creature within 10 spaces.'
 		},
 		{
 			featureName: 'Psionic Resolve',
 			levelGained: 2,
-			description: 'During combat, when you make an Attribute Save, you may spend 1 SP to instead roll a different Attribute Save of your choice.'
+			description:
+				'During combat, when you make an Attribute Save, you may spend 1 SP to instead roll a different Attribute Save of your choice.'
 		},
 		{
 			featureName: 'Talent',

--- a/src/lib/rulesdata/classes-data/features/rogue_features.ts
+++ b/src/lib/rulesdata/classes-data/features/rogue_features.ts
@@ -25,7 +25,6 @@ export const rogueClass: ClassDefinition = {
 	},
 	coreFeatures: [
 		{
-			id: 'rogue_expertise',
 			featureName: 'Expertise',
 			levelGained: 1,
 			description:
@@ -39,7 +38,6 @@ export const rogueClass: ClassDefinition = {
 			]
 		},
 		{
-			id: 'sneak_attack',
 			featureName: 'Sneak Attack',
 			levelGained: 1,
 			description:
@@ -53,7 +51,6 @@ export const rogueClass: ClassDefinition = {
 			]
 		},
 		{
-			id: 'thieves_cant',
 			featureName: "Thieves' Cant",
 			levelGained: 1,
 			description:
@@ -67,7 +64,6 @@ export const rogueClass: ClassDefinition = {
 			]
 		},
 		{
-			id: 'cunning_action',
 			featureName: 'Cunning Action',
 			levelGained: 2,
 			description: 'You can use your Minor Action to take the Disengage, Hide, or Dash action.',

--- a/src/lib/rulesdata/classes-data/features/sorcerer_features.ts
+++ b/src/lib/rulesdata/classes-data/features/sorcerer_features.ts
@@ -3,128 +3,332 @@ import type { ClassDefinition } from '../../schemas/character.schema';
 export const sorcererClass: ClassDefinition = {
 	className: 'Sorcerer',
 	startingEquipment: {
-		weaponsOrShields: ['2 Weapons'],
+		weaponsOrShields: ['1 Weapon'],
 		armor: '1 set of Light Armor',
-		packs: 'X or Y Packs (Adventuring Packs Coming Soon)'
+		packs: 'X or Y "Packs" (Adventuring Packs Coming Soon)',
 	},
 	spellcasterPath: {
-		spellsKnown: {
-			description: 'Spells Known column of the Sorcerer Class Table'
+		spellList: ['Arcane', 'Divine', 'Primal'],
+		cantrips: {
+			description:
+				'The number of Cantrips you know increases as shown in the Cantrips Known column of the Sorcerer Class Table.',
 		},
-		ritualCasting: false,
-		spellPreparation: false
+		spells: {
+			description:
+				'The number of Spells you know increases as shown in the Spells Known column of the Sorcerer Class Table.',
+		},
+		manaPoints: {
+			maximumIncreasesBy: 'as shown in the Mana Points column of the Sorcerer Class Table.',
+		},
 	},
 	coreFeatures: [
 		{
-			id: 'draconic_bloodline',
-			featureName: 'Draconic Bloodline',
+			featureName: 'Innate Power',
 			levelGained: 1,
 			description:
-				'Choose a draconic ancestor. You gain resistance to the associated damage type and bonus spells.',
-			effects: [
+				'Choose a Sorcerous Origin that grants you a benefit: Intuitive Magic, Resilient Magic, or Unstable Magic. Additionally, you gain the following benefits.',
+			benefits: [
 				{
-					type: 'GRANT_CHOICE',
-					target: 'draconic_bloodline',
-					value: {
-						prompt: 'Choose your Draconic Bloodline',
-						options: [
-							'red',
-							'blue',
-							'green',
-							'black',
-							'white',
-							'gold',
-							'silver',
-							'bronze',
-							'copper',
-							'brass'
-						]
-					},
-					userChoice: {
-						prompt: 'Choose your Draconic Ancestor',
-						options: [
-							'Red Dragon (Fire)',
-							'Blue Dragon (Lightning)',
-							'Green Dragon (Poison)',
-							'Black Dragon (Acid)',
-							'White Dragon (Cold)',
-							'Gold Dragon (Fire)',
-							'Silver Dragon (Cold)',
-							'Bronze Dragon (Lightning)',
-							'Copper Dragon (Acid)',
-							'Brass Dragon (Fire)'
-						]
-					}
-				}
-			]
+					name: 'Increased Maximum MP',
+					description: 'Your maximum MP increases by 1.',
+					effects: [{ type: 'MODIFY_STAT', target: 'mpMax', value: 1 }],
+				},
+				{
+					name: 'Free Spell Enhancement',
+					description:
+						'Once per Long Rest, you can use a 1 MP Spell Enhancement without spending any MP (up to your Mana Spend Limit). You regain the ability to use this benefit when you roll for Initiative.',
+					effects: [
+						{
+							type: 'GRANT_ABILITY',
+							target: 'free_spell_enhancement',
+							value: 'Once per Long Rest, use a 1 MP Spell Enhancement for free.',
+						},
+					],
+				},
+			],
+			choices: [
+				{
+					id: 'sorcerous_origin',
+					prompt: 'Choose a Sorcerous Origin',
+					count: 1,
+					options: [
+						{
+							name: 'Intuitive Magic',
+							description:
+								'Learn an additional Spell and Cantrip from your Sorcerer Spell List.',
+							effects: [
+								{
+									type: 'GRANT_SPELL',
+									target: 'sorcerer_spell_list',
+									value: 1,
+									userChoice: {
+										prompt: 'Choose an additional spell from the sorcerer list',
+									},
+								},
+								{
+									type: 'GRANT_CANTRIP',
+									target: 'sorcerer_spell_list',
+									value: 1,
+								},
+							],
+						},
+						{
+							name: 'Resilient Magic',
+							description: 'You gain Dazed Resistance.',
+							effects: [{ type: 'GRANT_RESISTANCE', target: 'Dazed', value: true }],
+						},
+						{
+							name: 'Unstable Magic',
+							description:
+								'When you Critically Succeed or Fail on a Spell Check, roll on the Wild Magic Table.',
+							effects: [
+								{
+									type: 'GRANT_ABILITY',
+									target: 'unstable_magic',
+									value:
+										'When you Critically Succeed or Fail on a Spell Check, roll on the Wild Magic Table.',
+								},
+							],
+						},
+					],
+				},
+			],
 		},
 		{
-			id: 'draconic_resilience',
-			featureName: 'Draconic Resilience',
+			featureName: 'Overload Magic',
 			levelGained: 1,
 			description:
-				'Your hit point maximum increases by 1, and it increases by 1 again whenever you gain a level in this class.',
-			effects: [
+				'You can spend 2 AP in Combat to channel raw magical energy for 1 minute, or until you become Incapacitated, die, or choose to end it early at any time for free.',
+			benefits: [
 				{
-					type: 'MODIFY_STAT',
-					target: 'hpMax',
-					value: 1
-				}
-			]
+					name: 'Spell Check Bonus',
+					description: 'You gain +5 to all Spell Checks you make.',
+					effects: [
+						{
+							type: 'MODIFY_STAT',
+							target: 'spellCheck',
+							value: 5,
+							condition: 'While Overload Magic is active',
+						},
+					],
+				},
+				{
+					name: 'Overload Strain',
+					description:
+						'You must immediately make an Attribute Save (your choice) against your Save DC upon using this Feature, and again at the start of each of your turns. Failure: you gain Exhaustion. You lose any Exhaustion gained in this way when you complete a Short Rest.',
+					effects: [
+						{
+							type: 'GRANT_ABILITY',
+							target: 'overload_strain',
+							value:
+								'Must save vs Exhaustion when using Overload Magic and at the start of each turn.',
+						},
+					],
+				},
+			],
 		},
 		{
-			id: 'sorcery_points',
-			featureName: 'Sorcery Points',
+			featureName: 'Sorcery',
+			levelGained: 1,
+			isFlavor: true,
+			description: 'You learn the Sorcery Spell.',
+			effects: [{ type: 'GRANT_SPELL', target: 'Sorcery', value: 1 }],
+		},
+		{
+			featureName: 'Meta Magic',
 			levelGained: 2,
 			description:
-				'You have sorcery points equal to your sorcerer level. You can use these to cast additional spells or enhance your magic.',
-			effects: [
+				"You gain 2 unique Spell Enhancements from the list below. You can only use 1 of these Spell Enhancements per Spell you cast. MP spent on these Spell Enhancements doesn't count against your Mana Spend Limit.",
+			choices: [
 				{
-					type: 'GRANT_RESOURCE',
-					target: 'sorcery_points',
-					value: 'level'
-				}
-			]
+					id: 'meta_magic_choice',
+					prompt: 'Choose 2 Spell Enhancements',
+					count: 2,
+					options: [
+						{
+							name: 'Careful Spell',
+							description:
+								"When you Cast a Spell that targets an Area of Effect, you can choose to protect some of the creatures from the Spell's full force. Spend 1 MP and choose a number of creatures up to your Prime Modifier. All chosen creatures are immune to the Spell's damage and effects.",
+							effects: [],
+						},
+						{
+							name: 'Heightened Spell',
+							description:
+								'When you Cast a Spell that forces a creature to make a Save to resist its effects, you can spend 1 MP to give 1 target DisADV on its first Save against the Spell.',
+							effects: [],
+						},
+						{
+							name: 'Quickened Spell',
+							description:
+								'You can spend 1 MP to reduce the AP cost of a Spell by 1 (minimum of 1 AP).',
+							effects: [],
+						},
+						{
+							name: 'Subtle Spell',
+							description:
+								'When you cast a Spell, you can spend 1 MP to cast it without any Somatic or Verbal Components.',
+							effects: [],
+						},
+						{
+							name: 'Transmuted Spell',
+							description:
+								'When you cast a Spell that deals a type of damage from the following list, you can spend 1 MP to change that damage type to one of the other listed types: Cold, Corrosion, Fire, Lightning, Poison, or Sonic.',
+							effects: [],
+						},
+					],
+				},
+			],
 		},
 		{
-			id: 'metamagic',
-			featureName: 'Metamagic',
-			levelGained: 3,
+			featureName: 'Talent',
+			levelGained: 2,
 			description:
-				'You gain the ability to twist your spells to suit your needs. You learn metamagic options that you can use with sorcery points.',
+				'You gain 1 Talent of your choice. If the Talent has any prerequisites, you must meet those prerequisites to choose that Talent.',
 			effects: [
 				{
 					type: 'GRANT_CHOICE',
-					target: 'metamagic_options',
-					value: {
-						prompt: 'Choose 2 Metamagic options',
-						count: 2,
-						options: [
-							'careful_spell',
-							'distant_spell',
-							'empowered_spell',
-							'extended_spell',
-							'heightened_spell',
-							'quickened_spell',
-							'subtle_spell',
-							'twinned_spell'
-						]
-					},
-					userChoice: {
-						prompt: 'Choose 2 Metamagic options',
-						options: [
-							'Careful Spell',
-							'Distant Spell',
-							'Empowered Spell',
-							'Extended Spell',
-							'Heightened Spell',
-							'Quickened Spell',
-							'Subtle Spell',
-							'Twinned Spell'
-						]
-					}
-				}
-			]
-		}
-	]
+					target: 'talent',
+					value: 1,
+					userChoice: { prompt: 'Choose 1 Talent' },
+				},
+			],
+		},
+	],
+	subclasses: [
+		{
+			subclassName: 'Angelic',
+			features: [
+				{
+					featureName: 'Celestial Spark',
+					levelGained: 1,
+					description:
+						'You can use a Minor Action to emit Bright Light within a 5 Space Radius and can end the effect at any time. You also gain the following abilities:',
+					benefits: [
+						{
+							name: 'Celestial Origin',
+							description: 'You gain 2 Ancestry Points that can only be spent on Angelborn Traits.',
+							effects: [
+								{
+									type: 'GRANT_ABILITY',
+									target: 'celestial_origin',
+									value: 'Gain 2 Ancestry Points for Angelborn Traits.',
+								},
+							],
+						},
+						{
+							name: 'Celestial Protection',
+							description:
+								'You learn the Careful Spell Meta Magic option (choose another Meta Magic option if you already know it) and Careful Spell now costs 0 MP to use.',
+							effects: [
+								{
+									type: 'GRANT_ABILITY',
+									target: 'careful_spell',
+									value: 'Learn Careful Spell. It costs 0 MP.',
+								},
+							],
+						},
+						{
+							name: 'Celestial Overload',
+							description:
+								"Once per Combat while you're Overloaded, you can spend 1 AP to release a burst of radiant light in a 5 Space Aura. Creatures of your choice within range are either healed or seared by the light (your choice for each creature).",
+							effects: [
+								{
+									type: 'GRANT_ABILITY',
+									target: 'celestial_overload',
+									value: 'Spend 1 AP while overloaded for AoE heal/damage.',
+								},
+							],
+						},
+					],
+				},
+				{
+					featureName: 'Celestial Appearance (Flavor Feature)',
+					levelGained: 1,
+					isFlavor: true,
+					description:
+						"You gain additional angelic features such as sparkling skin, feathers, a faint halo, or other changes of your choice. If you already have these features, they're enhanced or expanded upon. Additionally, if you're already Fluent in Celestial, you gain 1 level of Language Mastery in another Language of your choice.",
+					effects: [
+						{
+							type: 'GRANT_ABILITY',
+							target: 'celestial_appearance',
+							value:
+								'Gain angelic features. If already fluent in Celestial, gain 1 Language Mastery.',
+						},
+					],
+				},
+			],
+		},
+		{
+			subclassName: 'Draconic',
+			features: [
+				{
+					featureName: 'Draconic Spark',
+					levelGained: 1,
+					description: 'You gain the following abilities:',
+					benefits: [
+						{
+							name: 'Draconic Origin',
+							description:
+								'You gain 2 Ancestry Points that can only be spent on Dragonborn Traits. Additionally, choose a Draconic Origin from the Dragonborn Ancestry if you haven’t already.',
+							effects: [
+								{
+									type: 'GRANT_ABILITY',
+									target: 'draconic_origin',
+									value:
+										'Gain 2 Ancestry Points for Dragonborn Traits & choose a Draconic Origin.',
+								},
+							],
+						},
+						{
+							name: 'Draconic Overload',
+							description:
+								'While Overloaded, you gain Resistance (1) to Physical damage and your Draconic Origin damage type.',
+							effects: [
+								{
+									type: 'GRANT_RESISTANCE',
+									target: 'Physical',
+									value: 1,
+									condition: 'While Overloaded',
+								},
+								{
+									type: 'GRANT_RESISTANCE',
+									target: 'Draconic Origin Damage Type',
+									value: 1,
+									condition: 'While Overloaded',
+								},
+							],
+						},
+						{
+							name: 'Draconic Transmutation',
+							description:
+								'You gain the Transmuted Spell Meta Magic (choose another Meta Magic option if you already have Transmuted Spell). Transmuted Spell now costs you 0 MP to use if you change the damage type to your Draconic Origin damage type.',
+							effects: [
+								{
+									type: 'GRANT_ABILITY',
+									target: 'draconic_transmutation',
+									value:
+										'Gain Transmuted Spell. Cost is 0 MP if changing to Draconic Origin damage type.',
+								},
+							],
+						},
+					],
+				},
+				{
+					featureName: 'Draconic Appearance (Flavor Feature)',
+					levelGained: 1,
+					isFlavor: true,
+					description:
+						"You gain additional draconic features such as scales, fangs, claws, or other changes of your choice. If you already have these features, they're enhanced or expanded upon. Additionally, you gain 1 level of Language Mastery in Draconic. If you're already Fluent in Draconic, you gain 1 level of Language Mastery in another Language of your choice.",
+					effects: [
+						{
+							type: 'GRANT_ABILITY',
+							target: 'draconic_appearance',
+							value:
+								'Gain draconic features and 1 level of Language Mastery in Draconic (or another language if already fluent).',
+						},
+					],
+				},
+			],
+		},
+	],
 };

--- a/src/lib/rulesdata/classes-data/features/spellblade_features.ts
+++ b/src/lib/rulesdata/classes-data/features/spellblade_features.ts
@@ -26,16 +26,12 @@ export const spellbladeClass: ClassDefinition = {
 			}
 		},
 		spellcastingAspect: {
-			spellsKnown: {
-				description: 'Spells Known column of the Spellblade Class Table'
-			},
-			ritualCasting: true,
-			spellPreparation: true
+			ritualCasting: false,
+			spellPreparation: false
 		}
 	},
 	coreFeatures: [
 		{
-			id: 'fighting_style',
 			featureName: 'Fighting Style',
 			levelGained: 1,
 			description:
@@ -68,7 +64,6 @@ export const spellbladeClass: ClassDefinition = {
 			]
 		},
 		{
-			id: 'spellstrike',
 			featureName: 'Spellstrike',
 			levelGained: 2,
 			description:

--- a/src/lib/rulesdata/classes-data/features/warlock_features.ts
+++ b/src/lib/rulesdata/classes-data/features/warlock_features.ts
@@ -3,11 +3,11 @@ import type { ClassDefinition } from '../../schemas/character.schema';
 export const warlockClass: ClassDefinition = {
 	className: 'Warlock',
 	spellcasterPath: {
-		
 		spellList: {
 			type: 'all_schools',
 			schoolCount: 4,
-			description: 'You choose 4 Spell Schools. When you learn a new Spell, you can choose any Spell from the chosen Spell Schools.'
+			description:
+				'You choose 4 Spell Schools. When you learn a new Spell, you can choose any Spell from the chosen Spell Schools.'
 		},
 		cantrips: {
 			description: 'Cantrips Known column of the Warlock Class Table'
@@ -23,182 +23,282 @@ export const warlockClass: ClassDefinition = {
 		{
 			featureName: 'Warlock Contract',
 			levelGained: 1,
-			description: 'You have a binding agreement with your patron that allows you to make sacrifices in exchange for boons.',
+			description:
+				'You have a binding agreement with your patron that allows you to make sacrifices in exchange for boons.',
 			benefits: [
 				{
 					name: 'Hasty Bargain',
-					description: 'Once per turn when you make a Check, you can spend 1 HP to gain ADV on the Check.',
-					effects: [{
-						type: 'GRANT_ABILITY',
-						target: 'hasty_bargain',
-						value: 'Once per turn: spend 1 HP to gain ADV on a Check.'
-					}]
+					description:
+						'Once per turn when you make a Check, you can spend 1 HP to gain ADV on the Check.',
+					effects: [
+						{
+							type: 'GRANT_ABILITY',
+							target: 'hasty_bargain',
+							value: 'Once per turn: spend 1 HP to gain ADV on a Check.'
+						}
+					]
 				},
 				{
 					name: 'Desperate Bargain',
-					description: 'Once per Combat, you can spend 1 AP to regain an amount of HP equal to your Prime Modifier. When you do, you become Exposed until the end of your next turn.',
-					effects: [{
-						type: 'GRANT_ABILITY',
-						target: 'desperate_bargain',
-						value: 'Once per Combat: spend 1 AP to regain HP equal to your Prime Modifier, but become Exposed.'
-					}]
+					description:
+						'Once per Combat, you can spend 1 AP to regain an amount of HP equal to your Prime Modifier. When you do, you become Exposed until the end of your next turn.',
+					effects: [
+						{
+							type: 'GRANT_ABILITY',
+							target: 'desperate_bargain',
+							value:
+								'Once per Combat: spend 1 AP to regain HP equal to your Prime Modifier, but become Exposed.'
+						}
+					]
 				}
 			]
 		},
 		{
 			featureName: 'Pact Boon',
 			levelGained: 1,
-			description: 'You gain a Pact Boon from your Patron. Choose 1 of the following options: Weapon, Armor, Cantrip, or Familiar.',
-			choices: [{
-				id: 'warlock_pact_boon_0',
-				prompt: 'Choose your Pact Boon',
-				count: 1,
-				options: [{
-					name: 'Pact Weapon',
-					description: 'You can bond with a weapon, granting it magical properties and allowing you to summon it at will.',
-					effects: [
-						{ type: 'GRANT_ABILITY', target: 'pact_weapon_mastery', value: 'Considered to have Training with your Pact Weapon.' },
-						{ type: 'GRANT_CHOICE', target: 'maneuver_save', value: 2 },
-						{ type: 'GRANT_ABILITY', target: 'pact_weapon_style', value: 'Benefit from your Pact Weapon\'s Style Passive.' },
-						{ type: 'GRANT_ABILITY', target: 'pact_weapon_summon', value: 'Dismiss to and summon from a pocket dimension as a Minor Action.' }
+			description:
+				'You gain a Pact Boon from your Patron. Choose 1 of the following options: Weapon, Armor, Cantrip, or Familiar.',
+			choices: [
+				{
+					id: 'warlock_pact_boon_0',
+					prompt: 'Choose your Pact Boon',
+					count: 1,
+					options: [
+						{
+							name: 'Pact Weapon',
+							description:
+								'You can bond with a weapon, granting it magical properties and allowing you to summon it at will.',
+							effects: [
+								{
+									type: 'GRANT_ABILITY',
+									target: 'pact_weapon_mastery',
+									value: 'Considered to have Training with your Pact Weapon.'
+								},
+								{ type: 'GRANT_CHOICE', target: 'maneuver_save', value: 2 },
+								{
+									type: 'GRANT_ABILITY',
+									target: 'pact_weapon_style',
+									value: "Benefit from your Pact Weapon's Style Passive."
+								},
+								{
+									type: 'GRANT_ABILITY',
+									target: 'pact_weapon_summon',
+									value: 'Dismiss to and summon from a pocket dimension as a Minor Action.'
+								}
+							]
+						},
+						{
+							name: 'Pact Armor',
+							description:
+								'You can bond with a suit of armor, granting it magical properties and allowing you to summon it onto your body.',
+							effects: [
+								{
+									type: 'GRANT_ABILITY',
+									target: 'pact_armor_mastery',
+									value: 'Considered to have Training with your Pact Armor.'
+								},
+								{ type: 'GRANT_CHOICE', target: 'maneuver_defensive', value: 3 },
+								{ type: 'MODIFY_STAT', target: 'mdr', value: 1 },
+								{
+									type: 'GRANT_ABILITY',
+									target: 'pact_armor_summon',
+									value: 'Dismiss to and summon from a pocket dimension as a Minor Action.'
+								}
+							]
+						},
+						{
+							name: 'Pact Cantrip',
+							description:
+								'Choose a Spell you know with the Cantrip Spell Tag. It becomes your Pact Cantrip, gaining special benefits.',
+							effects: [
+								{
+									type: 'GRANT_ABILITY',
+									target: 'pact_cantrip',
+									value:
+										'Chosen cantrip deals +1 damage to Bloodied targets, its range increases, and you can grant yourself ADV on its Spell Check once per round.'
+								}
+							]
+						},
+						{
+							name: 'Pact Familiar',
+							description:
+								'You learn the Find Familiar Spell. When you cast it, your Familiar gains 3 additional Familiar Traits of your choice for free.',
+							effects: [
+								{ type: 'GRANT_SPELL', target: 'Find Familiar', value: 1 },
+								{
+									type: 'GRANT_ABILITY',
+									target: 'pact_familiar_bonus',
+									value: 'Your familiar gains 3 additional Familiar Traits for free.'
+								}
+							]
+						}
 					]
-				}, {
-					name: 'Pact Armor',
-					description: 'You can bond with a suit of armor, granting it magical properties and allowing you to summon it onto your body.',
-					effects: [
-						{ type: 'GRANT_ABILITY', target: 'pact_armor_mastery', value: 'Considered to have Training with your Pact Armor.' },
-						{ type: 'GRANT_CHOICE', target: 'maneuver_defensive', value: 3 },
-						{ type: 'MODIFY_STAT', target: 'mdr', value: 1 },
-						{ type: 'GRANT_ABILITY', target: 'pact_armor_summon', value: 'Dismiss to and summon from a pocket dimension as a Minor Action.' }
-					]
-				}, {
-					name: 'Pact Cantrip',
-					description: 'Choose a Spell you know with the Cantrip Spell Tag. It becomes your Pact Cantrip, gaining special benefits.',
-					effects: [{
-						type: 'GRANT_ABILITY',
-						target: 'pact_cantrip',
-						value: 'Chosen cantrip deals +1 damage to Bloodied targets, its range increases, and you can grant yourself ADV on its Spell Check once per round.'
-					}]
-				}, {
-					name: 'Pact Familiar',
-					description: 'You learn the Find Familiar Spell. When you cast it, your Familiar gains 3 additional Familiar Traits of your choice for free.',
-					effects: [
-						{ type: 'GRANT_SPELL', target: 'Find Familiar', value: 1 },
-						{ type: 'GRANT_ABILITY', target: 'pact_familiar_bonus', value: 'Your familiar gains 3 additional Familiar Traits for free.' }
-					]
-				}, ]
-			}]
+				}
+			]
 		},
 		{
 			featureName: 'Life Tap',
 			levelGained: 2,
-			description: 'When you produce an MP Effect, you can spend HP in place of MP. The total amount of HP and MP spent can\'t exceed your Mana Spend Limit. You can use this Feature once per Long Rest, and regain the ability to use it again when you roll for Initiative.',
-			effects: [{
-				type: 'GRANT_ABILITY',
-				target: 'life_tap',
-				value: 'Once per Long Rest, you can spend HP instead of MP for spell effects (regain on initiative).'
-			}]
+			description:
+				"When you produce an MP Effect, you can spend HP in place of MP. The total amount of HP and MP spent can't exceed your Mana Spend Limit. You can use this Feature once per Long Rest, and regain the ability to use it again when you roll for Initiative.",
+			effects: [
+				{
+					type: 'GRANT_ABILITY',
+					target: 'life_tap',
+					value:
+						'Once per Long Rest, you can spend HP instead of MP for spell effects (regain on initiative).'
+				}
+			]
 		},
 		{
 			featureName: 'Talent',
 			levelGained: 2,
-			description: 'You gain 1 Talent of your choice. If the Talent has any prerequisites, you must meet those prerequisites to choose that Talent.',
-			effects: [{
-				type: 'GRANT_CHOICE',
-				target: 'talent',
-				value: 1
-			}]
+			description:
+				'You gain 1 Talent of your choice. If the Talent has any prerequisites, you must meet those prerequisites to choose that Talent.',
+			effects: [
+				{
+					type: 'GRANT_CHOICE',
+					target: 'talent',
+					value: 1
+				}
+			]
 		}
 	],
-	subclasses: [{
-		subclassName: 'Eldritch',
-		description: 'Your patron gifts you with forbidden knowledge and psychic power.',
-		features: [{
-			featureName: 'Otherworldly Gift',
-			levelGained: 3, // Assuming subclass features start at level 3
-			description: 'Your patron grants you the following benefits: Psychic Spellcasting, Forbidden Knowledge, and an Eldritch Bargain.',
-			benefits: [{
-				name: 'Psychic Spellcasting',
-				description: 'You learn 1 Spell of your choice with the Psychic Spell Tag. When you learn a new Spell, you can choose any Spell that has the Psychic Spell Tag.',
-				effects: [{
-					type: 'GRANT_SPELL',
-					target: 'any_psychic_tag',
-					value: 1
-				}]
-			}, {
-				name: 'Forbidden Knowledge',
-				description: 'When you complete a Short or Long Rest, you temporarily learn any Spell of your choice. When you cast that Spell, its MP cost is reduced by 1 (minimum of 0). You forget the Spell immediately after you cast it.',
-				effects: [{
-					type: 'GRANT_ABILITY',
-					target: 'forbidden_knowledge',
-					value: 'Temporarily learn any spell after a rest with a 1 MP cost reduction.'
-				}]
-			}, {
-				name: 'Eldritch Bargain',
-				description: 'When you make an Attack against the PD or AD of a creature, you can spend 1 HP to target its other Defense instead.',
-				effects: [{
-					type: 'GRANT_ABILITY',
-					target: 'eldritch_bargain',
-					value: 'Spend 1 HP to target a creature\'s other defense (PD or AD) with an attack.'
-				}]
-			}]
-		}, {
-			featureName: 'Alien Comprehension (Flavor Feature)',
-			levelGained: 3,
-			isFlavor: true,
-			description: 'You become Fluent in Deep Speech, and you understand the writings and ramblings of lunatics.',
-			effects: [{
-				type: 'GRANT_ABILITY',
-				target: 'alien_comprehension',
-				value: 'Become fluent in Deep Speech and understand mad writings.'
-			}]
-		}]
-	}, {
-		subclassName: 'Fey',
-		description: 'Your patron is a lord or lady of the fey, granting you beguiling and tricky powers.',
-		features: [{
-			featureName: 'Fey Aspect',
-			levelGained: 3,
-			description: 'You gain benefits related to a Fey Aspect of your choice (Charmed or Intimidated).',
-			choices: [{
-				id: 'warlock_fey_aspect_0',
-				prompt: 'Choose your Fey Aspect Condition',
-				count: 1,
-				options: [{
-					name: 'Charmed',
-					description: 'Your Fey Aspect is the Charmed condition.',
-					effects: []
-				}, {
-					name: 'Intimidated',
-					description: 'Your Fey Aspect is the Intimidated condition.',
-					effects: []
-				}]
-			}],
-			benefits: [{
-				name: 'Can\'t Trick a Trickster',
-				description: 'You have ADV on Saves against your Fey Aspect Condition.',
-				effects: [{
-					type: 'GRANT_ADV_ON_SAVE',
-					target: 'Fey_Aspect_Condition',
-					value: true
-				}]
-			}, {
-				name: 'Fey Step',
-				description: 'When you\'re Hit by an Attack, you can spend 1 AP as a Reaction to teleport up to 3 Spaces and become Invisible until the start of your next turn. (Once per Long Rest, regain on initiative).',
-				effects: [{
-					type: 'GRANT_ABILITY',
-					target: 'fey_step',
-					value: 'Reaction teleport when hit, becoming invisible.'
-				}]
-			}, {
-				name: 'Beguiling Bargain',
-				description: 'Once on each of your turns when you cast a Spell or make an Attack, you can spend 1 HP to force a target to make a Charisma Save. Failure: You subject the target to your Fey Aspect Condition until the end of your next turn.',
-				effects: [{
-					type: 'GRANT_ABILITY',
-					target: 'beguiling_bargain',
-					value: 'Spend 1 HP on spell/attack to force a save against your Fey Aspect Condition.'
-				}]
-			}]
-		}]
-	}]
+	subclasses: [
+		{
+			subclassName: 'Eldritch',
+			description: 'Your patron gifts you with forbidden knowledge and psychic power.',
+			features: [
+				{
+					featureName: 'Otherworldly Gift',
+					levelGained: 3, // Assuming subclass features start at level 3
+					description:
+						'Your patron grants you the following benefits: Psychic Spellcasting, Forbidden Knowledge, and an Eldritch Bargain.',
+					benefits: [
+						{
+							name: 'Psychic Spellcasting',
+							description:
+								'You learn 1 Spell of your choice with the Psychic Spell Tag. When you learn a new Spell, you can choose any Spell that has the Psychic Spell Tag.',
+							effects: [
+								{
+									type: 'GRANT_SPELL',
+									target: 'any_psychic_tag',
+									value: 1
+								}
+							]
+						},
+						{
+							name: 'Forbidden Knowledge',
+							description:
+								'When you complete a Short or Long Rest, you temporarily learn any Spell of your choice. When you cast that Spell, its MP cost is reduced by 1 (minimum of 0). You forget the Spell immediately after you cast it.',
+							effects: [
+								{
+									type: 'GRANT_ABILITY',
+									target: 'forbidden_knowledge',
+									value: 'Temporarily learn any spell after a rest with a 1 MP cost reduction.'
+								}
+							]
+						},
+						{
+							name: 'Eldritch Bargain',
+							description:
+								'When you make an Attack against the PD or AD of a creature, you can spend 1 HP to target its other Defense instead.',
+							effects: [
+								{
+									type: 'GRANT_ABILITY',
+									target: 'eldritch_bargain',
+									value:
+										"Spend 1 HP to target a creature's other defense (PD or AD) with an attack."
+								}
+							]
+						}
+					]
+				},
+				{
+					featureName: 'Alien Comprehension (Flavor Feature)',
+					levelGained: 3,
+					isFlavor: true,
+					description:
+						'You become Fluent in Deep Speech, and you understand the writings and ramblings of lunatics.',
+					effects: [
+						{
+							type: 'GRANT_ABILITY',
+							target: 'alien_comprehension',
+							value: 'Become fluent in Deep Speech and understand mad writings.'
+						}
+					]
+				}
+			]
+		},
+		{
+			subclassName: 'Fey',
+			description:
+				'Your patron is a lord or lady of the fey, granting you beguiling and tricky powers.',
+			features: [
+				{
+					featureName: 'Fey Aspect',
+					levelGained: 3,
+					description:
+						'You gain benefits related to a Fey Aspect of your choice (Charmed or Intimidated).',
+					choices: [
+						{
+							id: 'warlock_fey_aspect_0',
+							prompt: 'Choose your Fey Aspect Condition',
+							count: 1,
+							options: [
+								{
+									name: 'Charmed',
+									description: 'Your Fey Aspect is the Charmed condition.',
+									effects: []
+								},
+								{
+									name: 'Intimidated',
+									description: 'Your Fey Aspect is the Intimidated condition.',
+									effects: []
+								}
+							]
+						}
+					],
+					benefits: [
+						{
+							name: "Can't Trick a Trickster",
+							description: 'You have ADV on Saves against your Fey Aspect Condition.',
+							effects: [
+								{
+									type: 'GRANT_ADV_ON_SAVE',
+									target: 'Fey_Aspect_Condition',
+									value: true
+								}
+							]
+						},
+						{
+							name: 'Fey Step',
+							description:
+								"When you're Hit by an Attack, you can spend 1 AP as a Reaction to teleport up to 3 Spaces and become Invisible until the start of your next turn. (Once per Long Rest, regain on initiative).",
+							effects: [
+								{
+									type: 'GRANT_ABILITY',
+									target: 'fey_step',
+									value: 'Reaction teleport when hit, becoming invisible.'
+								}
+							]
+						},
+						{
+							name: 'Beguiling Bargain',
+							description:
+								'Once on each of your turns when you cast a Spell or make an Attack, you can spend 1 HP to force a target to make a Charisma Save. Failure: You subject the target to your Fey Aspect Condition until the end of your next turn.',
+							effects: [
+								{
+									type: 'GRANT_ABILITY',
+									target: 'beguiling_bargain',
+									value:
+										'Spend 1 HP on spell/attack to force a save against your Fey Aspect Condition.'
+								}
+							]
+						}
+					]
+				}
+			]
+		}
+	]
 };

--- a/src/lib/rulesdata/schemas/character.schema.ts
+++ b/src/lib/rulesdata/schemas/character.schema.ts
@@ -61,6 +61,7 @@ export interface GrantResistanceEffect {
 	type: 'GRANT_RESISTANCE';
 	target: string;
 	value: string | number | boolean;
+	optional?: string;
 }
 
 export interface GrantVulnerabilityEffect {


### PR DESCRIPTION
- Fix GRANT_MANEUVERS boolean→number values in barbarian/commander (4 maneuvers)
- Add optional property to GrantResistanceEffect schema for conditional notes
- Remove invalid 'id' properties from ClassFeature objects (monk, rogue, spellblade)
- Remove unsupported 'spellsKnown' properties from spellcaster paths
- Fix maneuver choice effects to use GRANT_MANEUVERS instead of GRANT_CHOICE
- Remove invalid 'Mastery Progression' feature from monk
- Set correct ritual casting/spell preparation flags for spellblade

feat(rules): Overhaul Sorcerer class features

Replaces the outdated and incorrect Sorcerer class data with a complete implementation based on the latest source documents.

- Implements all Level 1 features: Innate Power (with 3 origin choices), Overload Magic, and Sorcery
- Adds all Level 2 features: Meta Magic (with 5 enhancement choices) and Talent
- Defines 'Angelic' and 'Draconic' subclasses with their respective features
- Corrects starting equipment and spellcaster path details
- Aligns the entire data structure with ClassDefinition schema

Resolves critical type errors that were blocking CI and could cause runtime failures in character creation for multiple classes.