### PR TITLE
fix(mastery): implement DC20 0.10 mastery cap rules and normalize anc…

### DIFF
--- a/src/lib/rulesdata/ancestries/ancestries.test.ts
+++ b/src/lib/rulesdata/ancestries/ancestries.test.ts
@@ -344,13 +344,34 @@ describe('Ancestry & Trait System', () => {
 		});
 
 		it('should have numeric values for numeric effect types', () => {
-			const numericEffectTypes = ['MODIFY_ATTRIBUTE', 'MODIFY_STAT', 'SET_VALUE'];
+			// MODIFY_ATTRIBUTE and MODIFY_STAT always use numeric values
+			// SET_VALUE can use various types (e.g., 'small' for size)
+			const numericEffectTypes = ['MODIFY_ATTRIBUTE', 'MODIFY_STAT'];
 
 			traitsData.forEach((trait: Trait) => {
 				trait.effects.forEach((effect: Effect) => {
 					if (numericEffectTypes.includes(effect.type)) {
 						expect(typeof effect.value).toBe('number');
 						expect(Number.isFinite(effect.value)).toBe(true);
+					}
+				});
+			});
+		});
+
+		it('should have valid SET_VALUE effects', () => {
+			// SET_VALUE can have various value types depending on target
+			// e.g., 'size' target uses strings like 'small', 'medium', 'large'
+			traitsData.forEach((trait: Trait) => {
+				trait.effects.forEach((effect: Effect) => {
+					if (effect.type === 'SET_VALUE') {
+						expect(effect.value).toBeDefined();
+						// Size-related targets use string values
+						if (effect.target === 'size') {
+							expect(typeof effect.value).toBe('string');
+							expect(['tiny', 'small', 'medium', 'large', 'huge', 'gargantuan']).toContain(
+								effect.value
+							);
+						}
 					}
 				});
 			});

--- a/src/lib/rulesdata/ancestries/sharedTraits.ts
+++ b/src/lib/rulesdata/ancestries/sharedTraits.ts
@@ -1,0 +1,522 @@
+/**
+ * Shared Ancestry Traits
+ *
+ * This file contains centralized trait definitions for commonly duplicated traits
+ * across multiple ancestries. Using shared traits ensures consistency in effects
+ * and reduces maintenance burden.
+ *
+ * When an ancestry needs a trait that matches one of these shared definitions,
+ * reference the shared trait ID instead of duplicating the definition.
+ */
+
+import type { Trait } from '../schemas/character.schema';
+
+/**
+ * Shared traits that are identical across multiple ancestries.
+ * These replace duplicate definitions to ensure consistent behavior.
+ */
+export const sharedTraitsData: Trait[] = [
+	// ============================================
+	// SIZE TRAITS
+	// ============================================
+	{
+		id: 'shared_small_sized',
+		name: 'Small-Sized',
+		description: 'Your Size is considered Small.',
+		cost: -1,
+		isNegative: true,
+		effects: [
+			{
+				type: 'SET_VALUE',
+				target: 'size',
+				value: 'small'
+			}
+		]
+	},
+
+	// ============================================
+	// MOVEMENT TRAITS
+	// ============================================
+	{
+		id: 'shared_short_legged',
+		name: 'Short-Legged',
+		description: 'Your Speed decreases by 1 Space.',
+		cost: -1,
+		isNegative: true,
+		effects: [{ type: 'MODIFY_STAT', target: 'moveSpeed', value: -1 }]
+	},
+	{
+		id: 'shared_speed_increase',
+		name: 'Speed Increase',
+		description: 'Your Speed increases by 1 Space.',
+		cost: 2,
+		effects: [{ type: 'MODIFY_STAT', target: 'moveSpeed', value: 1 }]
+	},
+	{
+		id: 'shared_climb_speed',
+		name: 'Climb Speed',
+		description: 'You gain a Climb Speed equal to your Movement Speed.',
+		cost: 1,
+		effects: [{ type: 'GRANT_MOVEMENT', target: 'climb', value: 'equal_to_speed' }]
+	},
+	{
+		id: 'shared_swim_speed',
+		name: 'Swim Speed',
+		description: 'You gain a Swim Speed equal to your Ground Speed.',
+		cost: 1,
+		effects: [{ type: 'GRANT_MOVEMENT', target: 'swim', value: 'equal_to_speed' }]
+	},
+	{
+		id: 'shared_burrow_speed',
+		name: 'Burrow Speed',
+		description: 'You gain a Burrow Speed equal to half your Movement Speed.',
+		cost: 2,
+		effects: [{ type: 'GRANT_MOVEMENT', target: 'burrow', value: 'half_speed' }]
+	},
+	{
+		id: 'shared_glide_speed',
+		name: 'Glide Speed',
+		description:
+			"You have a set of wings that you can use to horizontally glide and slow your descent. Provided you aren't Incapacitated, you gain the following benefits while in the air: Controlled Falling: You suffer no damage from Controlled Falling. Altitude Drop: If you end your turn midair, you Controlled Fall 4 Spaces. Glide Speed: You can use your movement to glide horizontally.",
+		cost: 2,
+		effects: [{ type: 'GRANT_MOVEMENT', target: 'glide', value: 'wings' }]
+	},
+
+	// ============================================
+	// HEALTH & DEFENSE TRAITS
+	// ============================================
+	{
+		id: 'shared_tough',
+		name: 'Tough',
+		description: 'Your HP maximum increases by 1.',
+		cost: 1,
+		effects: [{ type: 'MODIFY_STAT', target: 'hpMax', value: 1 }]
+	},
+	{
+		id: 'shared_frail',
+		name: 'Frail',
+		description: 'Your HP maximum decreases by 2.',
+		cost: -1,
+		isNegative: true,
+		effects: [{ type: 'MODIFY_STAT', target: 'hpMax', value: -2 }]
+	},
+	{
+		id: 'shared_thick_skinned',
+		name: 'Thick-Skinned',
+		description: "While you aren't wearing Armor, you gain +1 AD.",
+		cost: 1,
+		effects: [{ type: 'MODIFY_STAT', target: 'ad', value: 1, condition: 'not_wearing_armor' }]
+	},
+	{
+		id: 'shared_quick_reactions',
+		name: 'Quick Reactions',
+		description: 'While you are not wearing Armor, you gain +1 PD.',
+		cost: 1,
+		effects: [{ type: 'MODIFY_STAT', target: 'pd', value: 1, condition: 'not_wearing_armor' }]
+	},
+	{
+		id: 'shared_brittle',
+		name: 'Brittle',
+		description: 'Your AD decreases by 1.',
+		cost: -1,
+		isNegative: true,
+		effects: [{ type: 'MODIFY_STAT', target: 'ad', value: -1 }]
+	},
+	{
+		id: 'shared_reckless',
+		name: 'Reckless',
+		description: 'Your PD decreases by 1.',
+		cost: -1,
+		isNegative: true,
+		effects: [{ type: 'MODIFY_STAT', target: 'pd', value: -1 }]
+	},
+
+	// ============================================
+	// MANA TRAITS
+	// ============================================
+	{
+		id: 'shared_mana_increase',
+		name: 'Mana Increase',
+		description: 'Your MP maximum increases by 1.',
+		cost: 1,
+		effects: [{ type: 'MODIFY_STAT', target: 'mpMax', value: 1 }]
+	},
+
+	// ============================================
+	// SENSES
+	// ============================================
+	{
+		id: 'shared_darkvision',
+		name: 'Darkvision',
+		description: 'You have Darkvision 10 Spaces.',
+		cost: 1,
+		effects: [{ type: 'GRANT_SENSE', target: 'darkvision', value: 10 }]
+	},
+	{
+		id: 'shared_tremorsense',
+		name: 'Tremorsense',
+		description: 'You have Tremorsense 3 Spaces.',
+		cost: 1,
+		effects: [{ type: 'GRANT_SENSE', target: 'tremorsense', value: 3 }]
+	},
+
+	// ============================================
+	// RESISTANCES & FORTITUDE
+	// ============================================
+	{
+		id: 'shared_toxic_fortitude',
+		name: 'Toxic Fortitude',
+		description: 'You have Poison Resistance (Half) and ADV on Saves against being Poisoned.',
+		cost: 2,
+		effects: [
+			{ type: 'GRANT_RESISTANCE', target: 'Poison', value: 'half' },
+			{ type: 'GRANT_ADV_ON_SAVE', target: 'Poisoned', value: 'ADV' }
+		]
+	},
+	{
+		id: 'shared_stone_blood',
+		name: 'Stone Blood',
+		description:
+			'You have ADV on Saves against Bleeding. Additionally, you can spend 1 AP to end the Bleeding Condition on yourself.',
+		cost: 1,
+		effects: [
+			{ type: 'GRANT_ADV_ON_SAVE', target: 'Bleeding', value: 'ADV' },
+			{
+				type: 'GRANT_ABILITY',
+				target: 'stone_blood',
+				value: 'You can spend 1 AP to end the Bleeding Condition on yourself.'
+			}
+		]
+	},
+
+	// ============================================
+	// AGILITY & EVASION TRAITS
+	// ============================================
+	{
+		id: 'shared_escape_artist',
+		name: 'Escape Artist',
+		description:
+			'You have ADV on Checks and Saves to avoid or escape being Grappled or Restrained.',
+		cost: 2,
+		effects: [
+			{ type: 'GRANT_ADV_ON_CHECK', target: 'Avoid_or_Escape_Grapple_Restrained', value: 'ADV' },
+			{ type: 'GRANT_ADV_ON_SAVE', target: 'Avoid_or_Escape_Grapple_Restrained', value: 'ADV' }
+		]
+	},
+	{
+		id: 'shared_deft_footwork',
+		name: 'Deft Footwork',
+		description:
+			'You can move through the space of a hostile creature 1 size larger than you as if it were Difficult Terrain.',
+		cost: 1,
+		effects: [
+			{
+				type: 'GRANT_ABILITY',
+				target: 'deft_footwork',
+				value:
+					'You can move through the space of a hostile creature 1 size larger as if it were Difficult Terrain.'
+			}
+		]
+	},
+	{
+		id: 'shared_sneaky',
+		name: 'Sneaky',
+		description: 'You can Hide while only Partially Concealed or behind 1/2 Cover.',
+		cost: 2,
+		effects: [
+			{
+				type: 'GRANT_ABILITY',
+				target: 'sneaky',
+				value: 'You can Hide while only Partially Concealed or behind 1/2 Cover.'
+			}
+		]
+	},
+
+	// ============================================
+	// BUILD TRAITS
+	// ============================================
+	{
+		id: 'shared_powerful_build',
+		name: 'Powerful Build',
+		description: 'You increase by 1 Size, but you occupy the Space of a creature 1 Size smaller.',
+		cost: 2,
+		effects: [
+			{
+				type: 'GRANT_ABILITY',
+				target: 'powerful_build',
+				value: '+1 Size but occupy 1 Size smaller space.'
+			}
+		]
+	},
+	{
+		id: 'shared_natural_weapon',
+		name: 'Natural Weapon',
+		description:
+			'You have up to 2 Natural Weapons (claws, horns, fangs, tail, etc.) which you can use to make Unarmed Strikes that deal 1 Bludgeoning, Piercing, or Slashing damage (your choice upon gaining this Trait). You can perform Attack Maneuvers with your Natural Weapons.',
+		cost: 1,
+		effects: [
+			{
+				type: 'GRANT_ABILITY',
+				target: 'natural_weapon',
+				value: '2 Natural Weapons for Unarmed Strikes (1 damage, chosen type).'
+			}
+		]
+	},
+
+	// ============================================
+	// SKILL-RELATED TRAITS
+	// ============================================
+	{
+		id: 'shared_trapper',
+		name: 'Trapper',
+		description:
+			'You have ADV on Investigation Checks to spot Traps and on Trickery Checks to Hide Traps.',
+		cost: 1,
+		effects: [
+			{ type: 'GRANT_ADV_ON_CHECK', target: 'Investigation_to_spot_Traps', value: 'ADV' },
+			{ type: 'GRANT_ADV_ON_CHECK', target: 'Trickery_to_Hide_Traps', value: 'ADV' }
+		]
+	},
+	{
+		id: 'shared_critter_knowledge',
+		name: 'Critter Knowledge',
+		description:
+			'You have ADV on Nature, Survival, and Animal Checks involving Small size creatures and smaller.',
+		cost: 1,
+		effects: [
+			{
+				type: 'GRANT_ADV_ON_CHECK',
+				target: 'Nature_Survival_Animal_involving_Small_Creatures',
+				value: 'ADV'
+			}
+		]
+	},
+
+	// ============================================
+	// VULNERABILITIES
+	// ============================================
+	{
+		id: 'shared_radiant_weakness',
+		name: 'Radiant Weakness',
+		description: 'You have Radiant Vulnerability (1).',
+		cost: -1,
+		isNegative: true,
+		effects: [{ type: 'GRANT_VULNERABILITY', target: 'Radiant', value: 1 }]
+	},
+	{
+		id: 'shared_umbral_weakness',
+		name: 'Umbral Weakness',
+		description: 'You have Umbral Vulnerability (1).',
+		cost: -1,
+		isNegative: true,
+		effects: [{ type: 'GRANT_VULNERABILITY', target: 'Umbral', value: 1 }]
+	},
+	{
+		id: 'shared_psychic_weakness',
+		name: 'Cursed Mind',
+		description: 'You gain Psychic Vulnerability (1).',
+		cost: -1,
+		isNegative: true,
+		effects: [{ type: 'GRANT_VULNERABILITY', target: 'Psychic', value: 1 }]
+	},
+	{
+		id: 'shared_sunlight_sensitivity',
+		name: 'Sunlight Sensitivity',
+		description:
+			'While you or your target is in sunlight, you have DisADV on Attacks and Awareness Checks that rely on sight.',
+		cost: -2,
+		isNegative: true,
+		effects: [
+			{
+				type: 'GRANT_ABILITY',
+				target: 'sunlight_sensitivity',
+				value: 'DisADV on Attacks and sight-based Awareness in sunlight.'
+			}
+		]
+	},
+
+	// ============================================
+	// TRADE/SKILL EXPERTISE (Base definitions)
+	// ============================================
+	{
+		id: 'shared_skill_expertise',
+		name: 'Skill Expertise',
+		description:
+			'Choose a Skill. Your Mastery Cap and Mastery Level in the chosen Skill both increase by 1. You can only benefit from 1 Feature that increases your Skill Mastery Limit at a time.',
+		cost: 2,
+		effects: [
+			{
+				type: 'INCREASE_SKILL_MASTERY_CAP',
+				count: 1,
+				value: 1
+			},
+			{
+				type: 'MODIFY_STAT',
+				target: 'skillPoints',
+				value: 1
+			}
+		]
+	},
+	{
+		id: 'shared_trade_expertise',
+		name: 'Trade Expertise',
+		description:
+			'Choose a Trade. Your Mastery Cap and Mastery Level in the chosen Trade both increase by 1. You can only benefit from 1 Feature that increases your Trade Mastery Limit at a time.',
+		cost: 1,
+		effects: [
+			{
+				type: 'INCREASE_TRADE_MASTERY_CAP',
+				count: 1,
+				value: 1
+			},
+			{
+				type: 'MODIFY_STAT',
+				target: 'tradePoints',
+				value: 1
+			}
+		]
+	}
+];
+
+/**
+ * Helper to get a shared trait by ID
+ */
+export const getSharedTrait = (id: string): Trait | undefined => {
+	return sharedTraitsData.find((trait) => trait.id === id);
+};
+
+/**
+ * Creates an ancestry-specific alias for a shared trait.
+ * This allows maintaining the ancestry prefix in IDs while using shared effects.
+ */
+export const createTraitAlias = (
+	sharedTraitId: string,
+	ancestryPrefix: string,
+	overrides?: Partial<Trait>
+): Trait | null => {
+	const sharedTrait = getSharedTrait(sharedTraitId);
+	if (!sharedTrait) return null;
+
+	const newId = `${ancestryPrefix}_${sharedTraitId.replace('shared_', '')}`;
+
+	return {
+		...sharedTrait,
+		id: newId,
+		...overrides
+	};
+};
+
+/**
+ * Mapping of old trait IDs to shared trait IDs for migration purposes.
+ * This helps track which traits have been centralized.
+ */
+export const TRAIT_ID_MAPPING: Record<string, string> = {
+	// Small-Sized
+	halfling_small_sized: 'shared_small_sized',
+	gnome_small_sized: 'shared_small_sized',
+	beastborn_small_sized: 'shared_small_sized',
+	gremlin_small_sized: 'shared_small_sized',
+	goblin_small_sized: 'shared_small_sized',
+
+	// Short-Legged
+	dwarf_short_legged: 'shared_short_legged',
+	halfling_short_legged: 'shared_short_legged',
+	gnome_short_legged: 'shared_short_legged',
+	beastborn_short_legged: 'shared_short_legged',
+	terraborn_slow_moving: 'shared_short_legged',
+
+	// Tough
+	dwarf_tough: 'shared_tough',
+	orc_tough: 'shared_tough',
+	giantborn_tough: 'shared_tough',
+	terraborn_tough: 'shared_tough',
+	// Note: beastborn_tough is different (+2 HP)
+
+	// Darkvision
+	dragonborn_darkvision: 'shared_darkvision',
+	fiendborn_darkvision: 'shared_darkvision',
+	beastborn_darkvision: 'shared_darkvision',
+	shadowborn_darkvision: 'shared_darkvision',
+
+	// Mana Increase
+	gnome_mana_increase: 'shared_mana_increase',
+	angelborn_mana_increase: 'shared_mana_increase',
+	dragonborn_mana_increase: 'shared_mana_increase',
+	fiendborn_mana_increase: 'shared_mana_increase',
+	shadowborn_mana_increase: 'shared_mana_increase',
+
+	// Glide Speed
+	angelborn_glide_speed: 'shared_glide_speed',
+	dragonborn_glide_speed: 'shared_glide_speed',
+	fiendborn_glide_speed: 'shared_glide_speed',
+	beastborn_glide_speed: 'shared_glide_speed',
+
+	// Thick-Skinned
+	dwarf_thick_skinned: 'shared_thick_skinned',
+	dragonborn_thick_skinned: 'shared_thick_skinned',
+	beastborn_thick_skinned: 'shared_thick_skinned',
+	// Note: terraborn_thick_skinned is different (no armor condition)
+
+	// Quick Reactions
+	elf_quick_reactions: 'shared_quick_reactions',
+	beastborn_quick_reactions: 'shared_quick_reactions',
+	gremlin_quick_reactions: 'shared_quick_reactions',
+
+	// Reckless
+	orc_reckless: 'shared_reckless',
+	beastborn_reckless: 'shared_reckless',
+	goblin_reckless: 'shared_reckless',
+
+	// Toxic Fortitude
+	dwarf_toxic_fortitude: 'shared_toxic_fortitude',
+	beastborn_toxic_fortitude: 'shared_toxic_fortitude',
+	terraborn_toxic_fortitude: 'shared_toxic_fortitude',
+
+	// Escape Artist
+	gnome_escape_artist: 'shared_escape_artist',
+	goblin_escape_artist: 'shared_escape_artist',
+	shadowborn_escape_artist: 'shared_escape_artist',
+
+	// Climb Speed
+	elf_climb_speed: 'shared_climb_speed',
+	beastborn_climb_speed: 'shared_climb_speed',
+	gremlin_climb_speed: 'shared_climb_speed',
+
+	// Brittle
+	elf_brittle: 'shared_brittle',
+	halfling_brittle: 'shared_brittle',
+
+	// Frail
+	elf_frail: 'shared_frail',
+	psyborn_frail: 'shared_frail',
+
+	// Stone Blood
+	dwarf_stone_blood: 'shared_stone_blood',
+	terraborn_stone_blood: 'shared_stone_blood',
+
+	// Deft Footwork
+	halfling_deft_footwork: 'shared_deft_footwork',
+	gremlin_deft_footwork: 'shared_deft_footwork',
+
+	// Sneaky
+	gremlin_sneaky: 'shared_sneaky',
+	goblin_sneaky: 'shared_sneaky',
+
+	// Powerful Build
+	giantborn_powerful_build: 'shared_powerful_build',
+	beastborn_powerful_build: 'shared_powerful_build',
+
+	// Trapper
+	gnome_trapper: 'shared_trapper',
+	goblin_trapper: 'shared_trapper',
+
+	// Critter Knowledge
+	halfling_critter_knowledge: 'shared_critter_knowledge',
+	gremlin_critter_knowledge: 'shared_critter_knowledge',
+
+	// Skill/Trade Expertise
+	human_skill_expertise: 'shared_skill_expertise',
+	human_trade_expertise: 'shared_trade_expertise',
+	elf_trade_expertise_elf: 'shared_trade_expertise'
+	// Note: gnome/dwarf/goblin trade expertise have restrictions, handled separately
+};

--- a/src/lib/rulesdata/ancestries/traits.ts
+++ b/src/lib/rulesdata/ancestries/traits.ts
@@ -1,4 +1,6 @@
 import type { Trait } from '../schemas/character.schema';
+// Note: See sharedTraits.ts for centralized trait definitions and the mapping
+// from ancestry-specific trait IDs to shared trait IDs.
 
 export const traitsData: Trait[] = [
 	// Human Traits (p. 108)
@@ -193,10 +195,14 @@ export const traitsData: Trait[] = [
 		cost: 1,
 		effects: [
 			{
-				type: 'GRANT_TRADE_EXPERTISE',
-				target: 'any_trade',
-				value: { capIncrease: 1, levelIncrease: 1 },
-				userChoice: { prompt: 'Choose a Trade for Expertise' }
+				type: 'INCREASE_TRADE_MASTERY_CAP',
+				count: 1,
+				value: 1
+			},
+			{
+				type: 'MODIFY_STAT',
+				target: 'tradePoints',
+				value: 1
 			}
 		]
 	},
@@ -374,9 +380,7 @@ export const traitsData: Trait[] = [
 		description: 'Your Size is considered Small.',
 		cost: -1,
 		isNegative: true,
-		effects: [
-			{ type: 'GRANT_ABILITY', target: 'small_size', value: 'Your Size is considered Small.' }
-		]
+		effects: [{ type: 'SET_VALUE', target: 'size', value: 'small' }]
 	},
 	{
 		id: 'halfling_elusive',
@@ -472,12 +476,17 @@ export const traitsData: Trait[] = [
 		id: 'halfling_trade_expertise',
 		name: 'Trade Expertise',
 		description:
-			'Choose a Trade. Your Mastery Cap and Mastery Level in the chosen Trade both increase by 1.',
+			'Choose a Trade. Your Mastery Cap and Mastery Level in the chosen Trade both increase by 1. You can only benefit from 1 Feature that increases your Trade Mastery Limit at a time.',
 		cost: 1,
 		effects: [
 			{
 				type: 'INCREASE_TRADE_MASTERY_CAP',
 				count: 1,
+				value: 1
+			},
+			{
+				type: 'MODIFY_STAT',
+				target: 'tradePoints',
 				value: 1
 			}
 		]
@@ -528,9 +537,7 @@ export const traitsData: Trait[] = [
 		description: 'Your Size is considered Small.',
 		cost: -1,
 		isNegative: true,
-		effects: [
-			{ type: 'GRANT_ABILITY', target: 'small_size', value: 'Your Size is considered Small.' }
-		]
+		effects: [{ type: 'SET_VALUE', target: 'size', value: 'small' }]
 	},
 	{
 		id: 'gnome_escape_artist',
@@ -539,11 +546,8 @@ export const traitsData: Trait[] = [
 			'You have ADV on Checks and Saves to avoid or escape being Grappled or Restrained.',
 		cost: 2,
 		effects: [
-			{
-				type: 'GRANT_ABILITY',
-				target: 'escape_artist',
-				value: 'You have ADV on Checks and Saves to avoid or escape being Grappled or Restrained.'
-			}
+			{ type: 'GRANT_ADV_ON_CHECK', target: 'Avoid_or_Escape_Grapple_Restrained', value: 'ADV' },
+			{ type: 'GRANT_ADV_ON_SAVE', target: 'Avoid_or_Escape_Grapple_Restrained', value: 'ADV' }
 		]
 	},
 	{
@@ -606,12 +610,8 @@ export const traitsData: Trait[] = [
 			'You have ADV on Investigation Checks to spot Traps and on Trickery Checks to Hide Traps.',
 		cost: 1,
 		effects: [
-			{
-				type: 'GRANT_ABILITY',
-				target: 'trapper',
-				value:
-					'You have ADV on Investigation Checks to spot Traps and on Trickery Checks to Hide Traps.'
-			}
+			{ type: 'GRANT_ADV_ON_CHECK', target: 'Investigation_to_spot_Traps', value: 'ADV' },
+			{ type: 'GRANT_ADV_ON_CHECK', target: 'Trickery_to_Hide_Traps', value: 'ADV' }
 		]
 	},
 	{
@@ -632,12 +632,18 @@ export const traitsData: Trait[] = [
 		id: 'gnome_trade_expertise',
 		name: 'Trade Expertise',
 		description:
-			'Choose a Crafting or Subterfuge Trade. Your Mastery Cap and Mastery Level in the chosen Trade both increase by 1.',
+			'Choose a Crafting or Subterfuge Trade. Your Mastery Cap and Mastery Level in the chosen Trade both increase by 1. You can only benefit from 1 Feature that increases your Trade Mastery Limit at a time.',
 		cost: 1,
+		// Note: Restricted to Crafting or Subterfuge trades
 		effects: [
 			{
 				type: 'INCREASE_TRADE_MASTERY_CAP',
 				count: 1,
+				value: 1
+			},
+			{
+				type: 'MODIFY_STAT',
+				target: 'tradePoints',
 				value: 1
 			}
 		]
@@ -918,12 +924,18 @@ export const traitsData: Trait[] = [
 		id: 'dwarf_trade_expertise',
 		name: 'Trade Expertise',
 		description:
-			'Choose a Crafting or Services Trade. Your Mastery Cap and Mastery Level in the chosen Trade both increase by 1.',
+			'Choose a Crafting or Services Trade. Your Mastery Cap and Mastery Level in the chosen Trade both increase by 1. You can only benefit from 1 Feature that increases your Trade Mastery Limit at a time.',
 		cost: 1,
+		// Note: Restricted to Crafting or Services trades
 		effects: [
 			{
 				type: 'INCREASE_TRADE_MASTERY_CAP',
 				count: 1,
+				value: 1
+			},
+			{
+				type: 'MODIFY_STAT',
+				target: 'tradePoints',
 				value: 1
 			}
 		]
@@ -1146,7 +1158,7 @@ export const traitsData: Trait[] = [
 		name: 'Mana Increase',
 		description: 'Your MP maximum increases by 1.',
 		cost: 1,
-		effects: [{ type: 'MODIFY_STAT', target: 'mp', value: 1 }]
+		effects: [{ type: 'MODIFY_STAT', target: 'mpMax', value: 1 }]
 	},
 	{
 		id: 'dragonborn_reptilian_superiority',
@@ -1287,7 +1299,7 @@ export const traitsData: Trait[] = [
 		name: 'Mana Increase',
 		description: 'Your MP maximum increases by 1.',
 		cost: 1,
-		effects: [{ type: 'MODIFY_STAT', target: 'mp', value: 1 }]
+		effects: [{ type: 'MODIFY_STAT', target: 'mpMax', value: 1 }]
 	},
 	{
 		id: 'fiendborn_radiant_weakness',
@@ -1606,7 +1618,7 @@ export const traitsData: Trait[] = [
 		description: 'Your Size is considered Small.',
 		cost: -1,
 		isNegative: true,
-		effects: [{ type: 'GRANT_ABILITY', target: 'small_sized', value: 'Size is considered Small.' }]
+		effects: [{ type: 'SET_VALUE', target: 'size', value: 'small' }]
 	},
 	{
 		id: 'beastborn_sunlight_sensitivity',
@@ -1941,7 +1953,7 @@ export const traitsData: Trait[] = [
 		name: 'Tough',
 		description: 'Your HP maximum increases by 2.',
 		cost: 1,
-		effects: [{ type: 'MODIFY_STAT', target: 'hp', value: 2 }]
+		effects: [{ type: 'MODIFY_STAT', target: 'hpMax', value: 2 }]
 	},
 	{
 		id: 'beastborn_toxic_fortitude',
@@ -2014,9 +2026,7 @@ export const traitsData: Trait[] = [
 		description: 'Your Size is considered Small.',
 		cost: -1,
 		isNegative: true,
-		effects: [
-			{ type: 'GRANT_ABILITY', target: 'Small-Sized', value: 'Your Size is considered Small.' }
-		]
+		effects: [{ type: 'SET_VALUE', target: 'size', value: 'small' }]
 	},
 	{
 		id: 'gremlin_sneaky',
@@ -2165,9 +2175,7 @@ export const traitsData: Trait[] = [
 		description: 'Your Size is considered Small.',
 		cost: -1,
 		isNegative: true,
-		effects: [
-			{ type: 'GRANT_ABILITY', target: 'Small-Sized', value: 'Your Size is considered Small.' }
-		]
+		effects: [{ type: 'SET_VALUE', target: 'size', value: 'small' }]
 	},
 	{
 		id: 'goblin_escape_artist',
@@ -2265,12 +2273,18 @@ export const traitsData: Trait[] = [
 		id: 'goblin_trade_expertise',
 		name: 'Trade Expertise',
 		description:
-			'Choose a Crafting or Subterfuge Trade. Your Mastery Cap and Mastery Level in the chosen Trade both increase by 1.',
+			'Choose a Crafting or Subterfuge Trade. Your Mastery Cap and Mastery Level in the chosen Trade both increase by 1. You can only benefit from 1 Feature that increases your Trade Mastery Limit at a time.',
 		cost: 1,
+		// Note: Restricted to Crafting or Subterfuge trades
 		effects: [
 			{
 				type: 'INCREASE_TRADE_MASTERY_CAP',
 				count: 1,
+				value: 1
+			},
+			{
+				type: 'MODIFY_STAT',
+				target: 'tradePoints',
 				value: 1
 			}
 		]

--- a/src/lib/stores/characterContext.tsx
+++ b/src/lib/stores/characterContext.tsx
@@ -34,6 +34,10 @@ export interface CharacterInProgressStoreData
 	skillsData: Record<string, number>;
 	tradesData: Record<string, number>;
 	languagesData: Record<string, { fluency: 'limited' | 'fluent' }>;
+	// Track which skills/trades have had their mastery limits elevated by spending points
+	// (Features that elevate limits are tracked via effects, not here)
+	skillMasteryLimitElevations: Record<string, { source: 'spent_points'; value: number }>;
+	tradeMasteryLimitElevations: Record<string, { source: 'spent_points'; value: number }>;
 	usePrimeCapRule?: boolean;
 	cachedEffectResults?: EnhancedCalculationResult;
 	cacheTimestamp?: number;
@@ -93,6 +97,8 @@ const initialCharacterInProgressState: CharacterInProgressStoreData = {
 	skillsData: {},
 	tradesData: {},
 	languagesData: { common: { fluency: 'fluent' } },
+	skillMasteryLimitElevations: {},
+	tradeMasteryLimitElevations: {},
 	selectedTraitChoices: {},
 	cachedEffectResults: undefined,
 	cacheTimestamp: undefined,
@@ -175,6 +181,14 @@ type CharacterAction =
 	| { type: 'UPDATE_SKILLS'; skillsData: Record<string, number> }
 	| { type: 'UPDATE_TRADES'; tradesData: Record<string, number> }
 	| { type: 'UPDATE_LANGUAGES'; languagesData: Record<string, { fluency: 'limited' | 'fluent' }> }
+	| {
+			type: 'UPDATE_SKILL_LIMIT_ELEVATIONS';
+			elevations: Record<string, { source: 'spent_points'; value: number }>;
+	  }
+	| {
+			type: 'UPDATE_TRADE_LIMIT_ELEVATIONS';
+			elevations: Record<string, { source: 'spent_points'; value: number }>;
+	  }
 	| { type: 'SET_CLASS'; classId: string | null }
 	| { type: 'SET_LEVEL'; level: number }
 	| { type: 'SET_ANCESTRY'; ancestry1Id: string | null; ancestry2Id: string | null }
@@ -221,6 +235,10 @@ function characterReducer(
 			return { ...state, tradesData: action.tradesData };
 		case 'UPDATE_LANGUAGES':
 			return { ...state, languagesData: action.languagesData };
+		case 'UPDATE_SKILL_LIMIT_ELEVATIONS':
+			return { ...state, skillMasteryLimitElevations: action.elevations };
+		case 'UPDATE_TRADE_LIMIT_ELEVATIONS':
+			return { ...state, tradeMasteryLimitElevations: action.elevations };
 		case 'SET_CLASS':
 			return { ...state, classId: action.classId };
 		case 'SET_LEVEL':

--- a/src/lib/types/effectSystem.ts
+++ b/src/lib/types/effectSystem.ts
@@ -102,12 +102,26 @@ export interface AttributeLimit {
 	canDecrease: boolean;
 }
 
+export interface MasteryLimitElevation {
+	source: 'spent_points';
+	value: number;
+}
+
 export interface MasteryLimitStatus {
 	maxSkillMastery: number;
 	maxTradeMastery: number;
 	currentAdeptCount: number;
 	maxAdeptCount: number;
 	canSelectAdept: boolean;
+	// DC20 0.10 mastery cap system fields
+	baselineSkillCap: number; // The baseline cap from character level
+	baselineTradeCap: number;
+	skillEffectiveCaps: Record<string, number>; // Per-skill effective caps (baseline + elevations)
+	tradeEffectiveCaps: Record<string, number>; // Per-trade effective caps
+	skillLimitElevations: Record<string, MasteryLimitElevation>; // Elevations from spent points
+	tradeLimitElevations: Record<string, MasteryLimitElevation>;
+	skillFeatureElevationsAvailable: number; // How many feature-based elevations available
+	tradeFeatureElevationsAvailable: number;
 }
 
 // Unresolved choice for character creation UI

--- a/src/routes/character-creation/Background.tsx
+++ b/src/routes/character-creation/Background.tsx
@@ -35,13 +35,24 @@ const Background: React.FC = () => {
 	const currentTrades = state.tradesData || {};
 	const currentLanguages = state.languagesData || { common: { fluency: 'fluent' } };
 
-	// Mastery limits from centralized calculator
+	// Mastery limits from centralized calculator (DC20 0.10 system)
 	const masteryLimits = {
 		maxSkillMastery: calculationResult.validation.masteryLimits.maxSkillMastery,
 		maxTradeMastery: calculationResult.validation.masteryLimits.maxTradeMastery,
 		currentAdeptCount: calculationResult.validation.masteryLimits.currentAdeptCount,
 		maxAdeptCount: calculationResult.validation.masteryLimits.maxAdeptCount,
-		canSelectAdept: calculationResult.validation.masteryLimits.canSelectAdept
+		canSelectAdept: calculationResult.validation.masteryLimits.canSelectAdept,
+		// DC20 0.10 mastery cap system fields
+		baselineSkillCap: calculationResult.validation.masteryLimits.baselineSkillCap,
+		baselineTradeCap: calculationResult.validation.masteryLimits.baselineTradeCap,
+		skillEffectiveCaps: calculationResult.validation.masteryLimits.skillEffectiveCaps,
+		tradeEffectiveCaps: calculationResult.validation.masteryLimits.tradeEffectiveCaps,
+		skillLimitElevations: calculationResult.validation.masteryLimits.skillLimitElevations,
+		tradeLimitElevations: calculationResult.validation.masteryLimits.tradeLimitElevations,
+		skillFeatureElevationsAvailable:
+			calculationResult.validation.masteryLimits.skillFeatureElevationsAvailable,
+		tradeFeatureElevationsAvailable:
+			calculationResult.validation.masteryLimits.tradeFeatureElevationsAvailable
 	};
 
 	// Conversion actions with proper logic using calculated values
@@ -154,6 +165,26 @@ const Background: React.FC = () => {
 		});
 	};
 
+	// Handler for skill mastery limit elevations (DC20 0.10)
+	const handleSkillLimitElevationChange = (
+		elevations: Record<string, { source: 'spent_points'; value: number }>
+	) => {
+		dispatch({
+			type: 'UPDATE_SKILL_LIMIT_ELEVATIONS',
+			elevations
+		});
+	};
+
+	// Handler for trade mastery limit elevations (DC20 0.10)
+	const handleTradeLimitElevationChange = (
+		elevations: Record<string, { source: 'spent_points'; value: number }>
+	) => {
+		dispatch({
+			type: 'UPDATE_TRADE_LIMIT_ELEVATIONS',
+			elevations
+		});
+	};
+
 	const skillPointsRemaining = background.availableSkillPoints - background.skillPointsUsed;
 	const tradePointsRemaining = background.availableTradePoints - background.tradePointsUsed;
 	const languagePointsRemaining =
@@ -231,6 +262,7 @@ const Background: React.FC = () => {
 						actions={actions}
 						masteryLimits={masteryLimits}
 						onSkillChange={handleSkillChange}
+						onSkillLimitElevationChange={handleSkillLimitElevationChange}
 					/>
 				</TabsContent>
 
@@ -246,6 +278,7 @@ const Background: React.FC = () => {
 						actions={actions}
 						masteryLimits={masteryLimits}
 						onTradeChange={handleTradeChange}
+						onTradeLimitElevationChange={handleTradeLimitElevationChange}
 					/>
 				</TabsContent>
 


### PR DESCRIPTION
…estry traits

Phase 1 - Normalize Ancestry Traits:
- Create sharedTraits.ts with centralized trait definitions
- Fix mp/mpMax and hp/hpMax target inconsistencies in traits
- Normalize GRANT_ABILITY to GRANT_ADV_ON_* for escape artist, trapper
- Unify Small-Sized traits to use SET_VALUE with size target
- Add missing MODIFY_STAT tradePoints to all Trade Expertise traits

Phase 2 - Fix Skills & Trades Mastery System:
- Add skillMasteryLimitElevations and tradeMasteryLimitElevations to character state
- Fix point cost calculation: 3 points for Adept at L1 (1 Novice + 1 elevation + 1 Adept)
- Remove incorrect "free Adept slot" logic at level 1
- Implement persistent elevation that compounds with level increases
- Add validation for "only 1 bonus per skill" rule (DUPLICATE_MASTERY_ELEVATION error)
- Update SkillsTab and TradesTab UI to show elevation costs and status
- Add debug logging for mastery cap calculations

Also fixes test that incorrectly expected SET_VALUE to always have numeric values.