### PR TITLE
fix(character-list): wait for Convex auth before fetching characters

### DIFF
--- a/src/routes/character-creation/LoadCharacter.tsx
+++ b/src/routes/character-creation/LoadCharacter.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useConvexAuth } from 'convex/react';
 import type { SavedCharacter } from '../../lib/types/dataContracts';
 import { getInitializedCharacterState } from '../../lib/utils/storageUtils';
 import { getDefaultStorage } from '../../lib/storage';
@@ -47,6 +48,7 @@ import {
 function LoadCharacter() {
 	const { t } = useTranslation();
 	const navigate = useNavigate();
+	const { isAuthenticated, isLoading: authLoading } = useConvexAuth();
 	const [savedCharacters, setSavedCharacters] = useState<SavedCharacter[]>([]);
 	const [deleteModalOpen, setDeleteModalOpen] = useState(false);
 	const [characterToDelete, setCharacterToDelete] = useState<SavedCharacter | null>(null);
@@ -62,8 +64,10 @@ function LoadCharacter() {
 	const storage = useMemo(() => getDefaultStorage(), []);
 
 	useEffect(() => {
+		if (authLoading) return;
 		console.log('[GIMLI DEBUG] 🎬 LoadCharacter: Fetching characters...', {
-			storageType: storage.constructor.name
+			storageType: storage.constructor.name,
+			isAuthenticated
 		});
 
 		let isMounted = true;
@@ -83,7 +87,7 @@ function LoadCharacter() {
 		return () => {
 			isMounted = false;
 		};
-	}, [storage]);
+	}, [storage, isAuthenticated, authLoading]);
 
 	const handleCharacterClick = (character: SavedCharacter) => {
 		// Edit character
@@ -392,7 +396,7 @@ function LoadCharacter() {
 				{t('loadCharacter.pageTitle')}
 			</PageTitle>
 
-			{savedCharacters.length === 0 ? (
+			{authLoading ? null : savedCharacters.length === 0 ? (
 				<EmptyState
 					initial={{ opacity: 0, y: 20 }}
 					animate={{ opacity: 1, y: 0 }}


### PR DESCRIPTION
LoadCharacter ran a one-shot useEffect with [storage] deps only, firing before ConvexAuthProvider had resolved the session. The Convex `list` query returns [] for an anonymous request, leaving the page in an empty state after Google login. Hard-refresh worked because the auth token restored before the effect ran.

Subscribe to useConvexAuth, gate the fetch on !isLoading, and add isAuthenticated/authLoading to the effect deps so the list refetches once auth resolves (or when it flips later). Also suppress the empty state while auth is still loading to avoid the "no characters" flash.