### PR TITLE
[codex] Fix Convex saves for partial character state

### DIFF
--- a/docs/systems/CALCULATION_SYSTEM.MD
+++ b/docs/systems/CALCULATION_SYSTEM.MD
@@ -2,7 +2,7 @@
 
 > Purpose: Definitive guide to derived stat formulas, effect application order, mastery cap validation, and breakdown output.
 > Status: Active
-> Last Updated: 2026-06-26
+> Last Updated: 2026-06-27
 
 ---
 
@@ -106,7 +106,7 @@ This modular structure improves maintainability and makes the calculation pipeli
 ### Progression Gains (from Class + Path)
 
 - **Maneuvers Known** = `sum(progressionGains.totalManeuversKnown) + sum(pathBonuses.maneuvers)`
-- **Cantrips Known** = `sum(progressionGains.totalCantripsKnown) + sum(pathBonuses.cantrips)`
+- **Legacy Cantrip Grants** = `sum(progressionGains.totalCantripsKnown) + sum(pathBonuses.cantrips)`, normalized into ordinary spell-known slots
 - **Spells Known** = `sum(progressionGains.totalSpellsKnown) + sum(pathBonuses.spells)`
 - **Talents** = `sum(progressionGains.totalTalents)`
 - **Path Points** = `sum(progressionGains.totalPathPoints)`
@@ -146,9 +146,9 @@ Level 5 Expert Features are resolved from the class feature data using the exist
 
 **Spellcaster Path:**
 
-- Level 1: +3 MP, +1 cantrip, +1 spell
-- Level 2: +2 MP, +1 cantrip
-- Level 3: +2 MP, +1 cantrip, +1 spell
+- Level 1: +3 MP, +1 legacy cantrip grant normalized to a spell slot, +1 spell
+- Level 2: +2 MP, +1 legacy cantrip grant normalized to a spell slot
+- Level 3: +2 MP, +1 legacy cantrip grant normalized to a spell slot, +1 spell
 - Level 4: +2 MP, +1 spell
 
   ***

--- a/docs/systems/CHARACTER_CREATION_FLOW.MD
+++ b/docs/systems/CHARACTER_CREATION_FLOW.MD
@@ -86,7 +86,7 @@
   - Inputs: `state.finalName`, `state.finalPlayerName`
   - Completion rule: both fields non-empty
   - UI: name generation is a secondary inline action beside the character name input.
-  - Final actions: `Finish & Go to Sheet` is the primary action; `Print PDF` autosaves the completed character, exports from the saved record, then opens the saved character sheet.
+  - Final actions render below the Player Name field: `Finish & Go to Sheet` is the primary action; `Print PDF` autosaves the completed character, exports from the saved record, then opens the saved character sheet.
   - Outputs: final naming data for persistence
   - Agent/browser hooks: name fields expose `data-testid="character-name-input"` / `data-field-id="character-name"` and `data-testid="player-name-input"` / `data-field-id="player-name"`.
 

--- a/docs/systems/CHARACTER_CREATION_FLOW.MD
+++ b/docs/systems/CHARACTER_CREATION_FLOW.MD
@@ -1,6 +1,6 @@
 ### Character Creation Flow System Spec
 
-> Last Updated: 2026-06-26
+> Last Updated: 2026-06-27
 
 #### Purpose
 
@@ -66,8 +66,8 @@
 
 - **Stage 6 – Spells** (`Spells.tsx`, conditional)
   - Inputs: `ALL_SPELLS`, calculator spell slots/global magic profile, `state.selectedSpells`
-  - Completion rule: every current spell slot has a valid selected spell ID, no duplicate selected spells exist, global magic profile restrictions match, and slot-specific restrictions match.
-  - Spell filtering: source, school, and tag browsing filters are OR-based across selected facets; cost and sustained filters narrow results. Slot and Global Magic Profile eligibility use source restrictions only when present, then school-or-tag matching.
+  - Completion rule: every current spell slot has a valid selected spell ID, no duplicate selected spells exist, and each selected spell matches its slot's effective target.
+  - Spell filtering: the stage keeps an automatic active-slot cursor, starting with the first empty slot and advancing after each learned spell. Users can click a slot to override the cursor for targeted filling or replacement. Eligibility is evaluated per spell against the current target slot. Global class-progression slots use the Global Magic Profile; feature/talent slots use their own restrictions, and unrestricted feature slots do not inherit the global profile. Source, school, and tag browsing filters are OR-based across selected facets; cost and sustained filters narrow results.
   - Spell cards display cost, range, duration, sustained status, school, sources, and first mechanical effect description before selection.
   - Outputs: `state.selectedSpells`
   - Agent/browser hooks: spell cards expose `data-testid="spell-card-{spellId}"`, `data-spell-id`, and `data-option-id`; learn/forget controls expose `data-testid="spell-{spellId}-learn|forget"` and matching `data-action-id`.

--- a/docs/systems/CLASS_SYSTEM.MD
+++ b/docs/systems/CLASS_SYSTEM.MD
@@ -2,7 +2,7 @@
 
 > Purpose: Single reference for Classes, Features, Talents, and Level Progression.
 > Status: Active
-> Last Updated: 2026-06-24
+> Last Updated: 2026-06-27
 
 ---
 
@@ -286,7 +286,7 @@ npm run test:unit -- --project server --run src/lib/rulesdata/classes-data/class
 - Spell schools reorganized to 8 schools (Astromancy, Conjuration, Divination, Elemental, Enchantment, Invocation, Nullification, Transmutation)
 - Spell lists removed; spells are accessed by source (Arcane/Divine/Primal) and school
 - Class features updated with new effects and descriptions
-- **Slot-Based Spell System (M3.20)**: Classes now define individual spell/cantrip slots ("Pockets"), supporting highly specific restrictions (e.g., expanded schools) alongside broad global magic profiles.
+- **Slot-Based Spell System (M3.20)**: Classes now define individual spell slots ("Pockets"), supporting highly specific restrictions (e.g., expanded schools) alongside broad global magic profiles. Legacy cantrip grants are normalized into ordinary spell slots.
 - **Data-Driven Spell Restrictions**: Classes now define `spellRestrictions` (allowed sources, schools, and tags) to automatically filter available spells in the character creator.
 
 **Recent Updates (2026-06-01)**:

--- a/docs/systems/DATABASE_SYSTEM.MD
+++ b/docs/systems/DATABASE_SYSTEM.MD
@@ -2,7 +2,7 @@
 
 > Purpose: Persistence architecture for characters and DM Tools: hybrid localStorage/Convex storage, schemas, auth, migrations.
 > Status: Active
-> Last Updated: 2026-06-24
+> Last Updated: 2026-06-27
 
 ---
 
@@ -151,6 +151,16 @@ Local mode does not create a Convex client or mount Convex authentication, so
 `VITE_CONVEX_URL` is not required for the default localStorage application.
 When `VITE_USE_CONVEX=true`, startup requires `VITE_CONVEX_URL` and fails with a
 configuration error if it is missing.
+
+### 3.4 Runtime State Normalization
+
+`normalizeCharacterStateForStorage()` is the shared boundary normalizer for
+legacy or partial `SavedCharacter.characterState` data. It fills required
+runtime resource fields, UI defaults, inventory currency, notes, and array
+surfaces before storage consumers or Convex mutations handle the character.
+Convex writes must run character state through this normalizer because table
+validators require complete `resources.current` and currency fields, while
+older local or cloud records may contain partial nested objects.
 
 ---
 

--- a/docs/systems/EFFECT_SYSTEM.MD
+++ b/docs/systems/EFFECT_SYSTEM.MD
@@ -2,7 +2,7 @@
 
 > Purpose: Canonical catalog of `Effect.type` semantics, targets, choice resolution, and stacking rules used across Traits and Class Features.
 > Status: Active
-> Last Updated: 2026-06-24
+> Last Updated: 2026-06-27
 
 ---
 
@@ -30,26 +30,26 @@ All effect types are defined in `character.schema.ts` as a discriminated union. 
 
 ### Grants
 
-| Type                    | Target                                                    | Value                                                        | Special Fields                                      | Stacking                                                                       |
-| ----------------------- | --------------------------------------------------------- | ------------------------------------------------------------ | --------------------------------------------------- | ------------------------------------------------------------------------------ |
-| `GRANT_ABILITY`         | ability name                                              | `string` (description)                                       | --                                                  | De-duplicates                                                                  |
-| `GRANT_RESISTANCE`      | damage type                                               | `string \| number \| boolean`                                | `optional?: string`                                 | De-duplicates; **collected by `abilityCollection.ts`**                         |
-| `GRANT_VULNERABILITY`   | damage type                                               | `number`                                                     | --                                                  | De-duplicates; **collected by `abilityCollection.ts`**                         |
-| `GRANT_ADV_ON_SAVE`     | save type or condition target                             | `string \| boolean`                                          | --                                                  | De-duplicates; condition targets normalize by ID/name                          |
-| `GRANT_ADV_ON_CHECK`    | check type                                                | `string \| boolean`                                          | --                                                  | De-duplicates; collected as sheet-facing advantage text                        |
-| `GRANT_COMBAT_TRAINING` | training type (e.g., `Weapons`, `Spell_Focuses`)          | `boolean`                                                    | --                                                  | De-duplicates; **collected by `abilityCollection.ts`**                         |
-| `GRANT_SENSE`           | sense type (e.g., `darkvision`)                           | `number` (range)                                             | `mode?: 'set' \| 'increase' \| 'increase_existing'` | Highest set range wins; increases add; **collected by `abilityCollection.ts`** |
-| `GRANT_MOVEMENT`        | movement type (`climb`, `swim`, `fly`, `burrow`, `glide`) | speed formula or numeric spaces                              | --                                                  | De-duplicates                                                                  |
-| `GRANT_CHOICE`          | choice category                                           | `number`                                                     | `userChoice?: { prompt, options? }`                 | Per-choice                                                                     |
-| `GRANT_SKILL_EXPERTISE` | skill name                                                | `{ capIncrease, levelIncrease }`                             | `userChoice?: { prompt, count? }`                   | Per-skill                                                                      |
-| `GRANT_TRADE_EXPERTISE` | trade name                                                | `{ capIncrease, levelIncrease }`                             | `userChoice?: { prompt }`                           | Per-trade                                                                      |
+| Type                    | Target                                                    | Value                            | Special Fields                                      | Stacking                                                                       |
+| ----------------------- | --------------------------------------------------------- | -------------------------------- | --------------------------------------------------- | ------------------------------------------------------------------------------ |
+| `GRANT_ABILITY`         | ability name                                              | `string` (description)           | --                                                  | De-duplicates                                                                  |
+| `GRANT_RESISTANCE`      | damage type                                               | `string \| number \| boolean`    | `optional?: string`                                 | De-duplicates; **collected by `abilityCollection.ts`**                         |
+| `GRANT_VULNERABILITY`   | damage type                                               | `number`                         | --                                                  | De-duplicates; **collected by `abilityCollection.ts`**                         |
+| `GRANT_ADV_ON_SAVE`     | save type or condition target                             | `string \| boolean`              | --                                                  | De-duplicates; condition targets normalize by ID/name                          |
+| `GRANT_ADV_ON_CHECK`    | check type                                                | `string \| boolean`              | --                                                  | De-duplicates; collected as sheet-facing advantage text                        |
+| `GRANT_COMBAT_TRAINING` | training type (e.g., `Weapons`, `Spell_Focuses`)          | `boolean`                        | --                                                  | De-duplicates; **collected by `abilityCollection.ts`**                         |
+| `GRANT_SENSE`           | sense type (e.g., `darkvision`)                           | `number` (range)                 | `mode?: 'set' \| 'increase' \| 'increase_existing'` | Highest set range wins; increases add; **collected by `abilityCollection.ts`** |
+| `GRANT_MOVEMENT`        | movement type (`climb`, `swim`, `fly`, `burrow`, `glide`) | speed formula or numeric spaces  | --                                                  | De-duplicates                                                                  |
+| `GRANT_CHOICE`          | choice category                                           | `number`                         | `userChoice?: { prompt, options? }`                 | Per-choice                                                                     |
+| `GRANT_SKILL_EXPERTISE` | skill name                                                | `{ capIncrease, levelIncrease }` | `userChoice?: { prompt, count? }`                   | Per-skill                                                                      |
+| `GRANT_TRADE_EXPERTISE` | trade name                                                | `{ capIncrease, levelIncrease }` | `userChoice?: { prompt }`                           | Per-trade                                                                      |
 
 ### Spell and Maneuver Grants
 
 | Type              | Target                                       | Value              | Special Fields                      | Stacking                                              |
 | ----------------- | -------------------------------------------- | ------------------ | ----------------------------------- | ----------------------------------------------------- |
 | `GRANT_SPELL`     | spell restriction or specific spell          | `number \| string` | `userChoice?: { prompt, options? }` | Per-slot                                              |
-| `GRANT_CANTRIP`   | cantrip restriction                          | `number`           | --                                  | Per-slot                                              |
+| `GRANT_CANTRIP`   | legacy spell grant alias                     | `number`           | --                                  | Normalized to spell slots                             |
 | `GRANT_MANEUVERS` | maneuver type or `all_attack` (access grant) | `number`           | --                                  | Access grants don't add to budget; specific grants do |
 
 ### Mastery Cap Effects

--- a/docs/systems/LEVELING_SYSTEM.MD
+++ b/docs/systems/LEVELING_SYSTEM.MD
@@ -4,7 +4,7 @@
 > This document is the single authoritative reference for the character leveling system. It outlines the data flow, calculation logic, and UI interactions required to create a character at any level from 1 to 10 (DC20 v0.10.5 max level).
 >
 > **Status:** ✅ **Complete** - Core leveling functionality implemented with DC20 v0.10.5 progression tables.
-> **Last Updated:** 2026-06-24
+> **Last Updated:** 2026-06-27
 
 ---
 
@@ -138,8 +138,9 @@ Path points grant immediate bonuses to character resources based on allocation:
 | 4 | — | +1 |
 
 **Spellcaster Path Progression (DC20 v0.10 p.161):**
-| Path Level | Mana Points | Cantrips Learned | Spells Learned |
-|------------|-------------|------------------|----------------|
+Legacy cantrip grants are normalized into ordinary spell slots.
+| Path Level | Mana Points | Legacy Spell Grants | Spells Learned |
+|------------|-------------|---------------------|----------------|
 | 1 | +3 | +1 | +1 |
 | 2 | +2 | +1 | — |
 | 3 | +2 | +1 | +1 |

--- a/docs/systems/PDF_EXPORT_SYSTEM.MD
+++ b/docs/systems/PDF_EXPORT_SYSTEM.MD
@@ -3,7 +3,7 @@
 > Purpose
 >
 > Capture the architecture, scope, and acceptance criteria for exporting a calculated character sheet to the official DC20 fillable PDF. This document is the system overview aligned with existing docs (no separate planning spec is currently tracked in-repo).
-> Last Updated: 2026-06-26
+> Last Updated: 2026-06-27
 
 ---
 
@@ -41,7 +41,7 @@ Out of scope (tracked as future ideas in Section 8): flattened exports toggle, p
 - **PDF Templates**:
   - `src/lib/pdf/010/DC20 Beta 0.10 (fillable) Character Sheet.pdf`
   - `src/lib/pdf/095/DC20_Beta_0_9_5_(fillable)_Character_Sheet.pdf`
-- **UI Integration** — `src/routes/character-creation/LoadCharacter.tsx` provides the load-list "Export PDF" CTA. `src/routes/character-creation/CharacterCreation.tsx` also exposes a final-step "Print PDF" secondary action that completes/autosaves the character first, then exports from the saved record.
+- **UI Integration** — `src/routes/character-creation/LoadCharacter.tsx` provides the load-list "Export PDF" CTA. The character-creation final Name step exposes a "Print PDF" secondary action below the Player Name field; it completes/autosaves the character first, then exports from the saved record.
 - **Character Sheet Integration** — `src/routes/character-sheet/CharacterSheetClean.tsx` and `src/routes/character-sheet/CharacterSheetRedesign.tsx` re-read the saved record by ID before export.
 
 ---

--- a/docs/systems/PROJECT_TECHNICAL_OVERVIEW.MD
+++ b/docs/systems/PROJECT_TECHNICAL_OVERVIEW.MD
@@ -2,7 +2,7 @@
 
 > Purpose: Technical overview of the DC20Clean codebase: stack, scripts, testing, project structure, and contribution expectations.
 > Status: Active
-> Last Updated: 2026-06-26
+> Last Updated: 2026-06-27
 
 ## Tech Stack
 
@@ -22,6 +22,7 @@
 - Replace ad hoc hand-drawn SVG icons across the app with a consistent icon set, preferably `lucide-react` where an appropriate icon exists. Start with menu/reference-tool icons, then sheet action icons, builders, and popups.
 - Create a dedicated `docs/systems/UI_SYSTEM.MD` if UI conventions continue to grow beyond this overview. It should cover layout grids, icon usage, responsive rules, shared primitives, and visual QA expectations.
 - Userback feedback is a UI widget, not a storage system. The install snippet lives in `index.html`; `src/components/UserbackFeedback.tsx` adds compact route/character/target metadata. Do not send full saved characters, notes, inventory, or localStorage dumps.
+- The fixed top-right toolbar keeps authentication as the rightmost primary action. Language switching is secondary and must include text, not only a flag icon, so it cannot be mistaken for sign-in.
 
 ## Local Setup
 

--- a/docs/systems/SPELLS_SYSTEM.MD
+++ b/docs/systems/SPELLS_SYSTEM.MD
@@ -2,7 +2,7 @@
 
 > Purpose: Single reference for spell data model, assignment rules, UI flows, and validation.
 > Status: Active
-> Last Updated: 2026-06-19
+> Last Updated: 2026-06-27
 
 ---
 
@@ -49,14 +49,14 @@ interface Spell {
 	sources: SpellSource[]; // Arcane, Divine, Primal
 	school: SpellSchool; // 8 schools
 	tags: SpellTag[]; // Burning, Cold, Healing, etc.
-	isCantrip?: boolean;
+	isCantrip?: boolean; // legacy/source metadata only; not a separate learnable entity
 	isRitual?: boolean;
 	cost: SpellCost; // numeric AP; numeric or variable MP with an optional minimum
 	range: string;
 	duration: string;
 	sustained: boolean; // Maintain action each turn
 	effects: SpellEffect[];
-	cantripPassive?: string;
+	cantripPassive?: string; // legacy/source text field
 	enhancements: SpellEnhancement[]; // structured mixed/variable/alternative costs
 }
 ```
@@ -99,15 +99,16 @@ src/lib/rulesdata/spells-data/
 ### Utility Functions
 
 ```typescript
-// Get all spells
+// Get all spells. The selectable model is a flat spell list; legacy cantrip helpers
+// are source-taxonomy helpers, not separate learnable-entity APIs.
 import { ALL_SPELLS } from './spells-data';
 
 // Lookup functions
 getSpellById(id: string): Spell | undefined
 getSpellsBySchool(school: SpellSchool): Spell[]
 getSpellsBySource(source: SpellSource): Spell[]
-getCantrips(): Spell[]
-getNonCantrips(): Spell[]
+getCantrips(): Spell[] // legacy/source taxonomy helper
+getNonCantrips(): Spell[] // legacy/source taxonomy helper
 ```
 
 ---
@@ -163,7 +164,7 @@ npm run spells:validate:0105
 
 Generated output and `docs/migration/spells-v0105-report.json` are committed. The report is
 the deterministic audit artifact: it includes counts, school totals, parser exceptions, and
-one entry per spell with ID, source, school, tags, cost, range, duration, sustained/cantrip
+one entry per spell with ID, source, school, tags, cost, range, duration, sustained/legacy cantrip
 flags, enhancement count, and source line provenance. The old v0.10 school catalogs and
 overlay are not exported at runtime; `ALL_SPELLS` is the sole spell dataset.
 
@@ -192,18 +193,17 @@ explicit character migration.
 
 ### 4.2 Spells Known Slots (Pockets)
 
-- Individual "pockets" that grant a single spell or cantrip.
+- Individual "pockets" that grant a single spell from the flat spell list.
 - Can have **Specific Restrictions** (e.g., "Must be from the Elemental school").
 - Sources: Class Progression, Subclass Features, Talents (Grant Spell effect).
 - Selection is tracked per-slot: `Record<SlotID, SpellID>`.
 - Exact class grants such as `Charm` and `Call Familiar` resolve to canonical generated spell IDs instead of broad unrestricted slots.
-- `GRANT_SPELL` / `GRANT_CANTRIP` effects with unresolved `userChoice` metadata are skipped until the choice is present; resolved nested choices can narrow a slot by selected tag or school.
+- `GRANT_SPELL` / legacy `GRANT_CANTRIP` effects with unresolved `userChoice` metadata are skipped until the choice is present; resolved nested choices can narrow a slot by selected tag or school. `GRANT_CANTRIP` is normalized into an ordinary spell slot.
 - Tag-targeted grants such as Warlock Eldritch `any_psychic_tag` create tag-restricted slots rather than falling back to the global profile.
 
 ### 4.3 Validation Rules
 
-- **Type Mismatch**: Cantrips cannot fit into Spell slots and vice-versa.
-- **Restriction Mismatch**: Selected spells must match slot restrictions and the Global Magic Profile. Source restrictions narrow only when present; school and tag restrictions are OR-based, so a spell can qualify by matching an allowed school or an allowed tag. Exact spell restrictions remain exact-only.
+- **Restriction Mismatch**: Selected spells must match the effective target of the slot they fill. Global class-progression slots use the Global Magic Profile. Feature/talent slots use their own slot restrictions; unrestricted feature slots such as Bard Magical Secrets do not inherit the class global profile. Source restrictions narrow only when present; school and tag restrictions are OR-based, so a spell can qualify by matching an allowed school or an allowed tag. Exact spell restrictions remain exact-only.
 - **Exhaustion**: All available slots must be validly filled.
 
 ---
@@ -215,8 +215,9 @@ explicit character migration.
 - The Spells stage appears conditionally only when the calculator reports `spellsKnownSlots.length > 0`.
 - Each slot is an individual spell picker that respects:
   - Slot-level restrictions (specific school/source/tag requirements, with school/tag as OR)
-  - Global Magic Profile (source if present, then school or tag)
-  - Type matching (cantrip slots only accept cantrips, spell slots only accept spells)
+  - Global Magic Profile only for global class-progression slots
+- The UI maintains an automatic active-slot cursor. On entry, the first empty slot is targeted. After a spell is learned, the cursor advances to the next empty slot. Clicking any slot overrides the cursor for replacement or targeted filling.
+- The catalog is filtered against the active slot's effective target. If every slot is full and no override is active, the catalog can fall back to the union of spells that fit at least one current slot for review.
 - Source, school, and tag browsing filters are OR-based across selected facets; cost and sustained filters continue to narrow the result set.
 - Spell selection is tracked as `Record<SlotID, SpellID>` in `characterContext.tsx`.
 
@@ -256,5 +257,5 @@ explicit character migration.
 
 ---
 
-> Last updated: 2026-06-13
+> Last updated: 2026-06-27
 > Maintainer: @DC20Clean-Team

--- a/docs/systems/VERSIONING_SYSTEM.MD
+++ b/docs/systems/VERSIONING_SYSTEM.MD
@@ -2,7 +2,7 @@
 
 > Purpose: Canonical policy for schema, rules, PDF, and system-source versioning.
 > Status: Active
-> Last Updated: 2026-06-25
+> Last Updated: 2026-06-27
 
 ---
 
@@ -68,6 +68,9 @@ Required behavior:
 6. Recalculate all current-rules derived values that the calculator can determine from the migrated draft.
    - The draft must be stamped with `CURRENT_SCHEMA_VERSION`.
    - Recalculation must persist calculated display/export arrays such as resistances, vulnerabilities, senses, and combat training.
+   - The draft must normalize partial legacy `characterState` before save so
+     Convex can create the current-rules copy even when the source record has
+     incomplete nested runtime resources.
 7. Mark the draft as `rulesUpgradeStatus: "needs-review"` when retired/deprecated selections were removed or require player alternatives.
 8. Force unresolved retired/ambiguous choices through explicit user selection before treating the upgrade as complete.
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -94,8 +94,8 @@ function App() {
 			<StyledApp>
 				{/* Fixed top-right auth status on all pages */}
 				<FixedAuthStatus>
-					<AuthStatus />
 					<LanguageSwitcher />
+					<AuthStatus />
 				</FixedAuthStatus>
 				<BrowserRouter>
 					<UserbackFeedback />

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -10,9 +10,10 @@ const SwitcherButton = styled.button`
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	width: 2.5rem;
-	height: 2.5rem;
-	padding: 0;
+	gap: 0.375rem;
+	min-width: 3.75rem;
+	height: 2.25rem;
+	padding: 0 0.625rem;
 	background: rgba(168, 85, 247, 0.05);
 	border: 1px solid rgba(168, 85, 247, 0.4);
 	border-radius: 8px;
@@ -37,6 +38,11 @@ const SwitcherButton = styled.button`
 const FlagIcon = styled.span`
 	font-size: 1.25rem;
 	line-height: 1;
+`;
+
+const LanguageLabel = styled.span`
+	font-size: 0.75rem;
+	text-transform: uppercase;
 `;
 
 const Dropdown = styled.div<{ $isOpen: boolean }>`
@@ -121,8 +127,14 @@ export const LanguageSwitcher: React.FC = () => {
 
 	return (
 		<SwitcherContainer ref={containerRef}>
-			<SwitcherButton onClick={() => setIsOpen(!isOpen)} title="Select Language">
+			<SwitcherButton
+				type="button"
+				onClick={() => setIsOpen(!isOpen)}
+				title={`Language: ${getLanguageName(currentLanguage)}`}
+				aria-label={`Language: ${getLanguageName(currentLanguage)}`}
+			>
 				<FlagIcon>{getFlagIcon(currentLanguage)}</FlagIcon>
+				<LanguageLabel>{currentLanguage === 'en' ? 'EN' : 'ES'}</LanguageLabel>
 			</SwitcherButton>
 			<Dropdown $isOpen={isOpen}>
 				<DropdownItem $isActive={currentLanguage === 'en'} onClick={() => changeLanguage('en')}>

--- a/src/components/auth/AuthGuard.tsx
+++ b/src/components/auth/AuthGuard.tsx
@@ -98,9 +98,10 @@ export function FeatureGateButton({
 			</button>
 
 			<Dialog open={showSignIn} onOpenChange={setShowSignIn}>
-				<DialogContent className="border-purple-500/50 bg-transparent p-0 shadow-none">
+				<DialogContent className="w-[calc(100vw-2rem)] max-w-md border-0 bg-transparent p-0 shadow-none sm:max-w-md">
 					<SignIn
 						feature={feature}
+						className="max-w-none"
 						onSuccess={() => {
 							setShowSignIn(false);
 							onAction();

--- a/src/components/auth/AuthStatus.tsx
+++ b/src/components/auth/AuthStatus.tsx
@@ -23,7 +23,20 @@ export function AuthStatus({ className }: AuthStatusProps) {
 	}
 
 	if (isLoading) {
-		return null;
+		return (
+			<div className={className}>
+				<Button
+					type="button"
+					variant="outline"
+					size="sm"
+					className="border-purple-500/50 text-purple-200"
+					disabled
+					aria-busy="true"
+				>
+					{t('auth.signIn')}
+				</Button>
+			</div>
+		);
 	}
 
 	if (isAllowed) {

--- a/src/components/auth/AuthStatus.tsx
+++ b/src/components/auth/AuthStatus.tsx
@@ -56,9 +56,10 @@ export function AuthStatus({ className }: AuthStatusProps) {
 			</Button>
 
 			<Dialog open={showSignIn} onOpenChange={setShowSignIn}>
-				<DialogContent className="border-purple-500/50 bg-transparent p-0 shadow-none">
+				<DialogContent className="w-[calc(100vw-2rem)] max-w-md border-0 bg-transparent p-0 shadow-none sm:max-w-md">
 					<SignIn
 						feature="general"
+						className="max-w-none"
 						onSuccess={() => setShowSignIn(false)}
 						onCancel={() => setShowSignIn(false)}
 					/>

--- a/src/lib/services/calculatorModules/spellSystem.ts
+++ b/src/lib/services/calculatorModules/spellSystem.ts
@@ -111,7 +111,9 @@ export function generateSpellsKnownSlots(
 	const slots: SpellsKnownSlot[] = [];
 
 	// 1. Generate Global Class Progression Slots
-	for (let i = 0; i < progressionGains.totalSpellsKnown; i++) {
+	const totalProgressionSpellSlots =
+		(progressionGains.totalSpellsKnown ?? 0) + (progressionGains.totalCantripsKnown ?? 0);
+	for (let i = 0; i < totalProgressionSpellSlots; i++) {
 		slots.push({
 			id: `global_spell_${i}`,
 			type: 'spell',
@@ -187,7 +189,11 @@ export function generateSpellsKnownSlots(
 				slot.specificRestrictions!.exactSpellId ??= getExactSpellIdForTarget(target);
 
 				// Bard Magical Secrets (Special case: no restrictions)
-				if (target === 'any_source' || effect.source.id === 'bard_magical_secrets') {
+				if (
+					target === 'any_spell_list' ||
+					target === 'any_source' ||
+					effect.source.id === 'bard_magical_secrets'
+				) {
 					slot.specificRestrictions = {};
 				}
 

--- a/src/lib/services/calculatorModules/validation.ts
+++ b/src/lib/services/calculatorModules/validation.ts
@@ -22,7 +22,11 @@ import { attributesData } from '../../rulesdata/attributes';
 import { getLevelCaps } from '../../rulesdata/progression/levelCaps';
 import { getSpellById } from '../../rulesdata/spells-data';
 import { BuildStep } from '../../types/effectSystem';
-import { matchesGlobalMagicProfile, matchesSpellRestrictions } from '../spellFiltering';
+import {
+	matchesGlobalMagicProfile,
+	matchesSpellRestrictions,
+	matchesSpellSlot
+} from '../spellFiltering';
 
 /**
  * Validate attribute limits against level caps
@@ -403,27 +407,29 @@ export function runValidation(input: ValidationInput): ValidationResult {
 				return;
 			}
 
-			if (
-				slot.specificRestrictions &&
-				!matchesSpellRestrictions(spell, slot.specificRestrictions)
-			) {
-				const { exactSpellId, schools, tags } = slot.specificRestrictions;
-				const allowedParts = [
-					exactSpellId ? `exact spell ${exactSpellId}` : null,
-					schools?.length ? `schools: ${schools.join(', ')}` : null,
-					tags?.length ? `tags: ${tags.join(', ')}` : null
-				].filter(Boolean);
+			if (!matchesSpellSlot(spell, slot, globalMagicProfile)) {
+				if (
+					slot.specificRestrictions &&
+					!matchesSpellRestrictions(spell, slot.specificRestrictions)
+				) {
+					const { exactSpellId, sources, schools, tags } = slot.specificRestrictions;
+					const allowedParts = [
+						exactSpellId ? `exact spell ${exactSpellId}` : null,
+						sources?.length ? `sources: ${sources.join(', ')}` : null,
+						schools?.length ? `schools: ${schools.join(', ')}` : null,
+						tags?.length ? `tags: ${tags.join(', ')}` : null
+					].filter(Boolean);
 
-				errors.push({
-					step: BuildStep.SpellsAndManeuvers,
-					field: slotId,
-					code: 'SCHOOL_RESTRICTION' as any,
-					message: `${spell.name} does not match restrictions for ${slot.sourceName}: ${allowedParts.join(' or ')}`
-				});
-			}
+					errors.push({
+						step: BuildStep.SpellsAndManeuvers,
+						field: slotId,
+						code: 'SCHOOL_RESTRICTION' as any,
+						message: `${spell.name} does not match restrictions for ${slot.sourceName}: ${allowedParts.join(' or ')}`
+					});
+					return;
+				}
 
-			if (slot.isGlobal && globalMagicProfile) {
-				if (!matchesGlobalMagicProfile(spell, globalMagicProfile)) {
+				if (slot.isGlobal && !matchesGlobalMagicProfile(spell, globalMagicProfile)) {
 					errors.push({
 						step: BuildStep.SpellsAndManeuvers,
 						field: slotId,

--- a/src/lib/services/spellAssignment.ts
+++ b/src/lib/services/spellAssignment.ts
@@ -62,11 +62,11 @@ export const assignSpellsToCharacter = (options: SpellAssignmentOptions): SpellD
 		return [];
 	}
 
-	const cantripsToAssign = levelData.cantripsKnown || 0;
-	const spellsToAssign = levelData.spellsKnown || 0;
+	const legacyCantripGrants = levelData.cantripsKnown || 0;
+	const spellsToAssign = (levelData.spellsKnown || 0) + legacyCantripGrants;
 
 	debug.spells(`Assigning spells for ${className} level ${level}:`, {
-		cantripsToAssign,
+		legacyCantripGrants,
 		spellsToAssign,
 		availableSchools
 	});
@@ -79,31 +79,11 @@ export const assignSpellsToCharacter = (options: SpellAssignmentOptions): SpellD
 		availableSpells.map((s) => ({ name: s.name, school: s.school, isCantrip: s.isCantrip }))
 	);
 
-	// Separate cantrips and spells
-	const availableCantrips = availableSpells.filter((spell) => spell.isCantrip);
-	const availableRegularSpells = availableSpells.filter((spell) => !spell.isCantrip);
-
-	debug.spells(
-		`Available cantrips: ${availableCantrips.length}`,
-		availableCantrips.map((s) => s.name)
-	);
-	debug.spells(
-		`Available regular spells: ${availableRegularSpells.length}`,
-		availableRegularSpells.map((s) => s.name)
-	);
-
-	// Assign cantrips first
 	const assignedSpells: SpellData[] = [];
 
-	// Assign cantrips
-	for (let i = 0; i < cantripsToAssign && i < availableCantrips.length; i++) {
-		const cantrip = availableCantrips[i];
-		assignedSpells.push(createSpellData(cantrip));
-	}
-
-	// Assign regular spells
-	for (let i = 0; i < spellsToAssign && i < availableRegularSpells.length; i++) {
-		const spell = availableRegularSpells[i];
+	// Assign from the flat spell list. `isCantrip` is retained only as source metadata.
+	for (let i = 0; i < spellsToAssign && i < availableSpells.length; i++) {
+		const spell = availableSpells[i];
 		assignedSpells.push(createSpellData(spell));
 	}
 

--- a/src/lib/services/spellFiltering.test.ts
+++ b/src/lib/services/spellFiltering.test.ts
@@ -4,9 +4,11 @@ import {
 	matchesGlobalMagicProfile,
 	matchesSpellCost,
 	matchesSpellRestrictions,
+	matchesSpellSlot,
 	matchesSpellSustained,
 	matchesUserSpellFacets
 } from './spellFiltering';
+import type { SpellsKnownSlot } from '../types/effectSystem';
 
 const makeSpell = (overrides: Partial<Spell>): Spell =>
 	({
@@ -117,5 +119,49 @@ describe('spell filtering', () => {
 				tags: ['Summoning']
 			})
 		).toBe(false);
+	});
+
+	it('applies the global profile only to global slots', () => {
+		const spell = makeSpell({
+			id: 'fireball',
+			school: SpellSchool.Elemental,
+			tags: ['Fire']
+		});
+		const bardProfile = {
+			sources: [],
+			schools: [SpellSchool.Enchantment],
+			tags: ['Embolden', 'Enfeeble', 'Healing', 'Illusion', 'Sound'] as SpellTag[]
+		};
+		const globalSlot: SpellsKnownSlot = {
+			id: 'global_spell_0',
+			type: 'spell',
+			sourceName: 'Bard Progression',
+			isGlobal: true
+		};
+		const magicalSecretsSlot: SpellsKnownSlot = {
+			id: 'specialized_bard_magical_secrets_0_0',
+			type: 'spell',
+			sourceName: 'Magical Secrets',
+			isGlobal: false,
+			specificRestrictions: {}
+		};
+
+		expect(matchesSpellSlot(spell, globalSlot, bardProfile)).toBe(false);
+		expect(matchesSpellSlot(spell, magicalSecretsSlot, bardProfile)).toBe(true);
+	});
+
+	it('treats catalog isCantrip flags as display metadata for slot matching', () => {
+		const cantripFlaggedSpell = makeSpell({ isCantrip: true });
+		const spell = makeSpell({ isCantrip: false });
+		const spellSlot: SpellsKnownSlot = {
+			id: 'spell_slot',
+			type: 'spell',
+			sourceName: 'Spell Grant',
+			isGlobal: false,
+			specificRestrictions: {}
+		};
+
+		expect(matchesSpellSlot(spell, spellSlot)).toBe(true);
+		expect(matchesSpellSlot(cantripFlaggedSpell, spellSlot)).toBe(true);
 	});
 });

--- a/src/lib/services/spellFiltering.ts
+++ b/src/lib/services/spellFiltering.ts
@@ -111,3 +111,19 @@ export const matchesSpellRestrictions = (
 		matchesSchoolOrTag(spell, restrictions.schools, restrictions.tags)
 	);
 };
+
+export const matchesSpellSlot = (
+	spell: Spell,
+	slot: SpellsKnownSlot,
+	profile?: GlobalMagicProfile
+): boolean => {
+	if (!matchesSpellRestrictions(spell, slot.specificRestrictions)) {
+		return false;
+	}
+
+	if (slot.isGlobal) {
+		return Boolean(profile && matchesGlobalMagicProfile(spell, profile));
+	}
+
+	return true;
+};

--- a/src/lib/services/spellSystem.spec.ts
+++ b/src/lib/services/spellSystem.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { calculateCharacterWithBreakdowns } from './enhancedCharacterCalculator';
+import { generateSpellsKnownSlots } from './calculatorModules/spellSystem';
 
 // Helper to create a minimal character build data
 const createBaseBuild = (overrides = {}) => ({
@@ -232,6 +233,60 @@ describe('Spell System - Spells Known Slots', () => {
 		expect(
 			invalidResult.validation.errors.find((error) => error.field === psychicSlot!.id)
 		).toBeDefined();
+	});
+
+	it('allows Bard Magical Secrets slots to learn outside the Bard global profile', () => {
+		const result = calculateCharacterWithBreakdowns(
+			createBaseBuild({
+				classId: 'bard',
+				level: 1
+			}) as any
+		);
+		const magicalSecretsSlot = result.spellsKnownSlots.find(
+			(slot) => slot.sourceName === 'Magical Secrets'
+		);
+		const globalSlot = result.spellsKnownSlots.find((slot) => slot.isGlobal);
+
+		expect(magicalSecretsSlot).toBeDefined();
+		expect(magicalSecretsSlot?.isGlobal).toBe(false);
+		expect(globalSlot).toBeDefined();
+		expect(result.globalMagicProfile?.schools).toContain('Enchantment');
+		expect(result.globalMagicProfile?.tags).toContain('Healing');
+
+		const magicalSecretsResult = calculateCharacterWithBreakdowns(
+			createBaseBuild({
+				classId: 'bard',
+				level: 1,
+				selectedSpells: { [magicalSecretsSlot!.id]: 'fireball' }
+			}) as any
+		);
+		expect(
+			magicalSecretsResult.validation.errors.find((error) => error.field === magicalSecretsSlot!.id)
+		).toBeUndefined();
+
+		const globalResult = calculateCharacterWithBreakdowns(
+			createBaseBuild({
+				classId: 'bard',
+				level: 1,
+				selectedSpells: { [globalSlot!.id]: 'fireball' }
+			}) as any
+		);
+		expect(
+			globalResult.validation.errors.find(
+				(error) => error.field === globalSlot!.id && error.code === 'PROFILE_MISMATCH'
+			)
+		).toBeDefined();
+	});
+
+	it('treats legacy cantrip progression as normal spell slots', () => {
+		const slots = generateSpellsKnownSlots(
+			createBaseBuild({ classId: 'wizard' }) as any,
+			{ totalSpellsKnown: 1, totalCantripsKnown: 2 },
+			[]
+		);
+
+		expect(slots).toHaveLength(3);
+		expect(slots.every((slot) => slot.type === 'spell')).toBe(true);
 	});
 });
 

--- a/src/lib/storage/convexStorageAdapter.ts
+++ b/src/lib/storage/convexStorageAdapter.ts
@@ -16,7 +16,7 @@ import { api } from '../../../convex/_generated/api';
 import { getConvexClient } from '../convexClient';
 import { CURRENT_SCHEMA_VERSION } from '../types/schemaVersion';
 import { normalizeRulesVersion } from '../rulesdata/versioning/rulesVersion';
-import { normalizeSelectedTalents } from '../utils/storageUtils';
+import { normalizeCharacterStateForStorage, normalizeSelectedTalents } from '../utils/storageUtils';
 
 type StoredCharacterDoc = SavedCharacter & {
 	_id: string;
@@ -56,17 +56,7 @@ function sanitizeCharacterStateForConvex(
 	state: CharacterState | undefined
 ): CharacterState | undefined {
 	if (!state) return state;
-
-	return {
-		...state,
-		ui: {
-			manualDefenseOverrides: state.ui?.manualDefenseOverrides ?? {},
-			activeConditions: state.ui?.activeConditions ?? {},
-			combatToggles: {
-				isRaging: state.ui?.combatToggles?.isRaging ?? false
-			}
-		}
-	};
+	return normalizeCharacterStateForStorage(state);
 }
 
 function prepareCharacterForSave(character: SavedCharacter): SavedCharacter {

--- a/src/lib/types/effectSystem.ts
+++ b/src/lib/types/effectSystem.ts
@@ -499,7 +499,7 @@ export interface GlobalMagicProfile {
  */
 export interface SpellsKnownSlot {
 	id: string; // Unique ID for state tracking
-	type: 'spell' | 'cantrip';
+	type: 'spell';
 	sourceName: string; // UI Label: "Wizard Level 1", "Magical Secrets", etc.
 	isGlobal: boolean; // If true, uses character's GlobalMagicProfile as filter
 	assignedSpellId?: string; // ID of the spell filling this slot

--- a/src/lib/utils/storageUtils.spec.tsx
+++ b/src/lib/utils/storageUtils.spec.tsx
@@ -1,5 +1,9 @@
 import { describe, test, expect, beforeEach } from 'vitest';
-import { deserializeCharacterFromStorage, serializeCharacterForStorage } from './storageUtils';
+import {
+	deserializeCharacterFromStorage,
+	normalizeCharacterStateForStorage,
+	serializeCharacterForStorage
+} from './storageUtils';
 
 describe('storageUtils', () => {
 	beforeEach(() => {
@@ -63,5 +67,29 @@ describe('storageUtils', () => {
 		expect(parsed.schemaVersion).toBe('2.2.0');
 		expect(parsed.rulesVersion).toBe('dc20-0.10');
 		expect(parsed.selectedTraitIds).toEqual(['trait1']);
+	});
+
+	test('normalizeCharacterStateForStorage fills partial legacy resource state', () => {
+		const result = normalizeCharacterStateForStorage({
+			resources: { current: { currentHP: 3 } },
+			ui: { manualDefenseOverrides: {} },
+			inventory: { items: [], currency: {} },
+			notes: { playerNotes: 'legacy note' }
+		});
+
+		expect(result.resources.current).toEqual({
+			currentHP: 3,
+			currentSP: 0,
+			currentMP: 0,
+			currentGritPoints: 0,
+			currentRestPoints: 0,
+			tempHP: 0,
+			actionPointsUsed: 0,
+			exhaustionLevel: 0,
+			deathSteps: 0,
+			isDead: false
+		});
+		expect(result.inventory.currency).toEqual({ gold: 0, silver: 0, copper: 0 });
+		expect(result.notes.playerNotes).toBe('legacy note');
 	});
 });

--- a/src/lib/utils/storageUtils.ts
+++ b/src/lib/utils/storageUtils.ts
@@ -33,6 +33,23 @@ function normalizeRecord<T>(value: unknown, fallback: Record<string, T>): Record
 		: fallback;
 }
 
+function numberOrDefault(value: unknown, fallback: number): number {
+	return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+}
+
+function booleanOrDefault(value: unknown, fallback: boolean): boolean {
+	return typeof value === 'boolean' ? value : fallback;
+}
+
+function normalizeCurrency(value: unknown): CharacterState['inventory']['currency'] {
+	const currency = value && typeof value === 'object' ? (value as Record<string, unknown>) : {};
+	return {
+		gold: numberOrDefault(currency.gold, 0),
+		silver: numberOrDefault(currency.silver, 0),
+		copper: numberOrDefault(currency.copper, 0)
+	};
+}
+
 export function normalizeSelectedTalents(
 	talents: Record<string, number> | string[] | undefined
 ): Record<string, number> {
@@ -51,6 +68,91 @@ export function normalizeSelectedTalents(
 			.map(([talentId, count]) => [talentId, Number(count)])
 	);
 }
+
+/**
+ * Normalize legacy/partial runtime state into the strict shape accepted by
+ * localStorage consumers and Convex document validators.
+ */
+export const normalizeCharacterStateForStorage = (
+	state?: Partial<CharacterState> | any
+): CharacterState => {
+	const defaults = getDefaultCharacterState();
+	const resources = state?.resources ?? {};
+	const current = resources.current ?? {};
+	const original = resources.original;
+	const ui = state?.ui ?? {};
+	const inventory = state?.inventory ?? {};
+	const normalizedState: CharacterState = {
+		resources: {
+			current: {
+				currentHP: numberOrDefault(current.currentHP, defaults.resources.current.currentHP),
+				currentSP: numberOrDefault(current.currentSP, defaults.resources.current.currentSP),
+				currentMP: numberOrDefault(current.currentMP, defaults.resources.current.currentMP),
+				currentGritPoints: numberOrDefault(
+					current.currentGritPoints,
+					defaults.resources.current.currentGritPoints
+				),
+				currentRestPoints: numberOrDefault(
+					current.currentRestPoints,
+					defaults.resources.current.currentRestPoints
+				),
+				tempHP: numberOrDefault(current.tempHP, defaults.resources.current.tempHP),
+				actionPointsUsed: numberOrDefault(
+					current.actionPointsUsed,
+					defaults.resources.current.actionPointsUsed
+				),
+				exhaustionLevel: numberOrDefault(
+					current.exhaustionLevel,
+					defaults.resources.current.exhaustionLevel
+				),
+				deathSteps: numberOrDefault(current.deathSteps, defaults.resources.current.deathSteps),
+				isDead: booleanOrDefault(current.isDead, defaults.resources.current.isDead)
+			}
+		},
+		ui: {
+			manualDefenseOverrides:
+				ui.manualDefenseOverrides && typeof ui.manualDefenseOverrides === 'object'
+					? ui.manualDefenseOverrides
+					: {},
+			activeConditions:
+				ui.activeConditions && typeof ui.activeConditions === 'object' ? ui.activeConditions : {},
+			combatToggles: {
+				isRaging: booleanOrDefault(ui.combatToggles?.isRaging, false)
+			}
+		},
+		inventory: {
+			items: Array.isArray(inventory.items) ? inventory.items : [],
+			currency: normalizeCurrency(inventory.currency)
+		},
+		notes: {
+			playerNotes: typeof state?.notes?.playerNotes === 'string' ? state.notes.playerNotes : ''
+		},
+		activeConditions: Array.isArray(state?.activeConditions)
+			? state.activeConditions.filter(
+					(condition: unknown): condition is string => typeof condition === 'string'
+				)
+			: [],
+		attacks: Array.isArray(state?.attacks) ? state.attacks : [],
+		spells: Array.isArray(state?.spells) ? state.spells : [],
+		maneuvers: Array.isArray(state?.maneuvers) ? state.maneuvers : []
+	};
+
+	if (original && typeof original === 'object') {
+		normalizedState.resources.original = {
+			maxHP: numberOrDefault(original.maxHP, 0),
+			maxSP: numberOrDefault(original.maxSP, 0),
+			maxMP: numberOrDefault(original.maxMP, 0),
+			maxGritPoints: numberOrDefault(original.maxGritPoints, 0),
+			maxRestPoints: numberOrDefault(original.maxRestPoints, 0)
+		};
+	}
+
+	if (state?.defenseOverrides && typeof state.defenseOverrides === 'object') {
+		normalizedState.defenseOverrides = state.defenseOverrides;
+	}
+
+	return normalizedState;
+};
 
 /**
  * Centralized JSON serialization for localStorage
@@ -92,27 +194,18 @@ export const deserializeCharacterFromStorage = (jsonString: string): SavedCharac
 			selectedTalents: normalizeSelectedTalents(data.selectedTalents),
 			spells: data.spells || [],
 			maneuvers: data.maneuvers || [],
-			characterState: {
-				...(data.characterState || getDefaultCharacterState()),
-				// Normalize attacks from object to array format for backward compatibility
+			characterState: normalizeCharacterStateForStorage({
+				...(data.characterState || {}),
 				attacks: Array.isArray(data.characterState?.attacks)
 					? data.characterState.attacks
 					: Object.values(data.characterState?.attacks || {}),
-				// Normalize spells to array if not already
 				spells: Array.isArray(data.characterState?.spells)
 					? data.characterState.spells
 					: data.spells || [],
-				// Normalize maneuvers to array if not already
 				maneuvers: Array.isArray(data.characterState?.maneuvers)
 					? data.characterState.maneuvers
-					: data.maneuvers || [],
-				ui: {
-					manualDefenseOverrides: data.characterState?.ui?.manualDefenseOverrides || {},
-					combatToggles: {
-						isRaging: data.characterState?.ui?.combatToggles?.isRaging ?? false
-					}
-				}
-			},
+					: data.maneuvers || []
+			}),
 			rulesVersion: normalizeRulesVersion(data.rulesVersion),
 			schemaVersion: CURRENT_SCHEMA_VERSION // Always update to current version
 		} as SavedCharacter;

--- a/src/routes/character-creation/CharacterCreation.tsx
+++ b/src/routes/character-creation/CharacterCreation.tsx
@@ -1029,9 +1029,10 @@ const CharacterCreation: React.FC<CharacterCreationProps> = ({ editCharacter }) 
 					if (!open) setPendingCompletionAction(null);
 				}}
 			>
-				<DialogContent className="border-purple-500/50 bg-transparent p-0 shadow-none">
+				<DialogContent className="w-[calc(100vw-2rem)] max-w-md border-0 bg-transparent p-0 shadow-none sm:max-w-md">
 					<SignIn
 						feature="cloud-save"
+						className="max-w-none"
 						onSuccess={() => setShowAuthDialog(false)}
 						onCancel={() => {
 							setShowAuthDialog(false);

--- a/src/routes/character-creation/CharacterCreation.tsx
+++ b/src/routes/character-creation/CharacterCreation.tsx
@@ -908,7 +908,12 @@ const CharacterCreation: React.FC<CharacterCreationProps> = ({ editCharacter }) 
 			case 'maneuvers':
 				return <Maneuvers />;
 			case 'name':
-				return <CharacterName />;
+				return (
+					<CharacterName
+						onFinish={() => void completeCurrentCharacter('sheet')}
+						onPrintPdf={() => void completeCurrentCharacter('pdf')}
+					/>
+				);
 			default:
 				return null;
 		}
@@ -985,22 +990,11 @@ const CharacterCreation: React.FC<CharacterCreationProps> = ({ editCharacter }) 
 
 					{/* Right: Next Button */}
 					<NavSection $align="end">
-						{state.currentStep === maxStep && (
-							<SecondaryButton
-								onClick={() => void completeCurrentCharacter('pdf')}
-								data-testid="creation-print-pdf"
-							>
-								{t('characterCreation.printPdf')}
-							</SecondaryButton>
+						{state.currentStep !== maxStep && (
+							<PrimaryButton onClick={handleNext} data-testid="creation-next">
+								<span>{t('characterCreation.next')}</span> →
+							</PrimaryButton>
 						)}
-						<PrimaryButton onClick={handleNext} data-testid="creation-next">
-							<span>
-								{state.currentStep === maxStep
-									? t('characterCreation.finishAndGoToSheet')
-									: t('characterCreation.next')}
-							</span>{' '}
-							→
-						</PrimaryButton>
 					</NavSection>
 					<RestartButton onClick={handleRestart} title={t('characterCreation.restartTooltip')}>
 						{t('characterCreation.restart')}

--- a/src/routes/character-creation/CharacterName.styled.ts
+++ b/src/routes/character-creation/CharacterName.styled.ts
@@ -119,6 +119,17 @@ export const SuggestionsGrid = styled.div`
 	}
 `;
 
+export const FinalActions = styled.div`
+	display: flex;
+	justify-content: flex-end;
+	gap: ${theme.spacing[3]};
+	padding-top: ${theme.spacing[2]};
+
+	${media.mobile} {
+		flex-direction: column;
+	}
+`;
+
 export const SuggestionButton = styled.button`
 	padding: ${theme.spacing[2]} ${theme.spacing[3]};
 	background: ${theme.colors.bg.secondary};

--- a/src/routes/character-creation/CharacterName.tsx
+++ b/src/routes/character-creation/CharacterName.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useCharacter } from '../../lib/stores/characterContext';
 import { nameByRace } from 'fantasy-name-generator';
-import { SecondaryButton } from '../../components/styled/index';
+import { PrimaryButton, SecondaryButton } from '../../components/styled/index';
 import { useTranslation } from 'react-i18next';
 import {
 	Container,
@@ -18,6 +18,7 @@ import {
 	GeneratorText,
 	SuggestionsGrid,
 	SuggestionButton,
+	FinalActions,
 	EmptyState
 } from './CharacterName.styled';
 
@@ -46,7 +47,12 @@ const generateNamesFromNPM = (race: string): string[] => {
 	}
 };
 
-function CharacterName() {
+interface CharacterNameProps {
+	onFinish?: () => void;
+	onPrintPdf?: () => void;
+}
+
+function CharacterName({ onFinish, onPrintPdf }: CharacterNameProps) {
 	const { state, dispatch } = useCharacter();
 	const { t } = useTranslation();
 	const [characterName, setCharacterName] = useState(state.finalName || '');
@@ -236,6 +242,17 @@ function CharacterName() {
 							placeholder={t('characterCreation.enterYourName')}
 						/>
 					</FormGroup>
+
+					{onFinish && onPrintPdf && (
+						<FinalActions>
+							<SecondaryButton onClick={onPrintPdf} data-testid="creation-print-pdf">
+								{t('characterCreation.printPdf')}
+							</SecondaryButton>
+							<PrimaryButton onClick={onFinish} data-testid="creation-next">
+								<span>{t('characterCreation.finishAndGoToSheet')}</span> →
+							</PrimaryButton>
+						</FinalActions>
+					)}
 				</FormGrid>
 			</FormCard>
 		</Container>

--- a/src/routes/character-creation/Spells.test.tsx
+++ b/src/routes/character-creation/Spells.test.tsx
@@ -1,0 +1,111 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import Spells from './Spells';
+import { SpellSchool } from '../../lib/rulesdata/schemas/spell.schema';
+import type { GlobalMagicProfile, SpellsKnownSlot } from '../../lib/types/effectSystem';
+
+const { mockDispatch, mockState, mockCalculationResult } = vi.hoisted(() => ({
+	mockDispatch: vi.fn(),
+	mockState: {
+		classId: 'bard',
+		selectedSpells: {},
+		selectedManeuvers: []
+	},
+	mockCalculationResult: {
+		globalMagicProfile: undefined as GlobalMagicProfile | undefined,
+		spellsKnownSlots: [] as SpellsKnownSlot[]
+	}
+}));
+
+vi.mock('../../lib/stores/characterContext', () => ({
+	useCharacter: () => ({
+		state: mockState,
+		dispatch: mockDispatch,
+		calculationResult: mockCalculationResult
+	})
+}));
+
+vi.mock('react-i18next', () => ({
+	useTranslation: () => ({ t: (key: string) => key })
+}));
+
+const bardProfile: GlobalMagicProfile = {
+	sources: [],
+	schools: [SpellSchool.Enchantment],
+	tags: ['Healing', 'Illusion', 'Sound']
+};
+
+const bardProgressionSlot: SpellsKnownSlot = {
+	id: 'global_bard_0',
+	type: 'spell',
+	sourceName: 'Bard Progression',
+	isGlobal: true
+};
+
+const magicalSecretsSlot: SpellsKnownSlot = {
+	id: 'bard_magical_secrets_0',
+	type: 'spell',
+	sourceName: 'Magical Secrets',
+	isGlobal: false,
+	specificRestrictions: {}
+};
+
+describe('Spells slot cursor', () => {
+	beforeEach(() => {
+		mockDispatch.mockReset();
+		mockState.selectedSpells = {};
+		mockCalculationResult.globalMagicProfile = bardProfile;
+		mockCalculationResult.spellsKnownSlots = [bardProgressionSlot, magicalSecretsSlot];
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('targets the first empty slot and advances after learning a spell', async () => {
+		render(<Spells />);
+
+		expect(await screen.findByText(/for Bard Progression/)).toBeInTheDocument();
+		expect(screen.getByTestId('spell-charm-learn')).toBeInTheDocument();
+		expect(screen.queryByTestId('spell-fireball-learn')).not.toBeInTheDocument();
+
+		fireEvent.click(screen.getByTestId('spell-charm-learn'));
+
+		expect(await screen.findByText(/for Magical Secrets/)).toBeInTheDocument();
+		expect(await screen.findByTestId('spell-fireball-learn')).toBeInTheDocument();
+
+		await waitFor(() => {
+			expect(mockDispatch).toHaveBeenCalledWith(
+				expect.objectContaining({
+					type: 'UPDATE_SPELLS_AND_MANEUVERS',
+					spells: { global_bard_0: 'charm' }
+				})
+			);
+		});
+	});
+
+	it('lets the user override the active slot before learning', async () => {
+		render(<Spells />);
+
+		expect(await screen.findByText(/for Bard Progression/)).toBeInTheDocument();
+		expect(screen.queryByTestId('spell-fireball-learn')).not.toBeInTheDocument();
+
+		fireEvent.click(screen.getByText('Magical Secrets'));
+
+		expect(await screen.findByText(/for Magical Secrets/)).toBeInTheDocument();
+		expect(await screen.findByTestId('spell-fireball-learn')).toBeInTheDocument();
+
+		fireEvent.click(screen.getByTestId('spell-fireball-learn'));
+
+		expect(await screen.findByText(/for Bard Progression/)).toBeInTheDocument();
+
+		await waitFor(() => {
+			expect(mockDispatch).toHaveBeenCalledWith(
+				expect.objectContaining({
+					type: 'UPDATE_SPELLS_AND_MANEUVERS',
+					spells: { bard_magical_secrets_0: 'fireball' }
+				})
+			);
+		});
+	});
+});

--- a/src/routes/character-creation/Spells.tsx
+++ b/src/routes/character-creation/Spells.tsx
@@ -5,12 +5,12 @@ import { formatSpellCost } from '../../lib/rulesdata/spells-data/spellCost';
 import { SpellSchool, SpellSource, type SpellTag } from '../../lib/rulesdata/schemas/spell.schema';
 import { classesData } from '../../lib/rulesdata/loaders/class.loader';
 import {
-	matchesGlobalMagicProfile,
 	matchesSpellCost,
-	matchesSpellRestrictions,
+	matchesSpellSlot,
 	matchesSpellSustained,
 	matchesUserSpellFacets
 } from '../../lib/services/spellFiltering';
+import type { SpellsKnownSlot } from '../../lib/types/effectSystem';
 import { theme } from '../character-sheet/styles/theme';
 import { SecondaryButton } from '../../components/styled/index';
 import { useTranslation } from 'react-i18next';
@@ -49,11 +49,56 @@ type CostFilter = 'all' | '1mp' | '2mp' | '3mp+';
 // Sustained filter options
 type SustainedFilter = 'all' | 'yes' | 'no';
 
+const getSlotRestrictionWeight = (slot: SpellsKnownSlot): number => {
+	const restrictions = slot.specificRestrictions;
+	const restrictionCount =
+		(restrictions?.sources?.length ?? 0) +
+		(restrictions?.schools?.length ?? 0) +
+		(restrictions?.tags?.length ?? 0);
+
+	if (restrictions?.exactSpellId) {
+		return 100;
+	}
+
+	if (restrictionCount > 0) {
+		return 50 + restrictionCount;
+	}
+
+	if (slot.isGlobal) {
+		return 25;
+	}
+
+	return 0;
+};
+
+const getNextEmptySlotId = (
+	slots: SpellsKnownSlot[],
+	selected: Record<string, string>,
+	afterSlotId?: string | null
+): string | null => {
+	if (slots.length === 0) {
+		return null;
+	}
+
+	const afterIndex = afterSlotId ? slots.findIndex((slot) => slot.id === afterSlotId) : -1;
+	const startIndex = afterIndex >= 0 ? afterIndex + 1 : 0;
+
+	for (let offset = 0; offset < slots.length; offset++) {
+		const slot = slots[(startIndex + offset) % slots.length];
+		if (!selected[slot.id]) {
+			return slot.id;
+		}
+	}
+
+	return null;
+};
+
 const Spells: React.FC = () => {
 	const { state, dispatch, calculationResult } = useCharacter();
 	const { t } = useTranslation();
 	const [selectedSpells, setSelectedSpells] = useState<Record<string, string>>({});
 	const [activeSlotId, setActiveSlotId] = useState<string | null>(null);
+	const [isManualSlotOverride, setIsManualSlotOverride] = useState(false);
 	const isInitialLoad = useRef(true);
 	const hasInitialized = useRef(false);
 
@@ -92,6 +137,33 @@ const Spells: React.FC = () => {
 
 	const spellSlots = calculationResult?.spellsKnownSlots || [];
 	const globalMagicProfile = calculationResult?.globalMagicProfile;
+	const nextEmptySlotId = useMemo(
+		() => getNextEmptySlotId(spellSlots, selectedSpells),
+		[spellSlots, selectedSpells]
+	);
+	const activeSlot = useMemo(
+		() => spellSlots.find((slot) => slot.id === activeSlotId) ?? null,
+		[activeSlotId, spellSlots]
+	);
+	const effectiveActiveSlot =
+		activeSlot ?? spellSlots.find((slot) => slot.id === nextEmptySlotId) ?? null;
+
+	useEffect(() => {
+		const activeSlotExists = Boolean(
+			activeSlotId && spellSlots.some((slot) => slot.id === activeSlotId)
+		);
+
+		if (isManualSlotOverride && activeSlotExists) {
+			return;
+		}
+
+		if (activeSlotId === nextEmptySlotId) {
+			return;
+		}
+
+		setIsManualSlotOverride(false);
+		setActiveSlotId(nextEmptySlotId);
+	}, [activeSlotId, isManualSlotOverride, nextEmptySlotId, spellSlots]);
 
 	// Debug class data lookup
 	useEffect(() => {
@@ -112,7 +184,7 @@ const Spells: React.FC = () => {
 		});
 	}, [spellSlots.length, selectedSpells]);
 
-	// Calculate available spells for the character based on Global Profile
+	// Calculate available spells from the effective target slot(s).
 	const availableSpells = useMemo(() => {
 		debug.spells('Calculating available spells:', {
 			hasClassData: !!classData,
@@ -134,23 +206,14 @@ const Spells: React.FC = () => {
 			return [];
 		}
 
-		// Debug: Log first few spells to see their structure
-		if (allSpells.length > 0) {
-			debug.spells('Sample spell structure:', {
-				spell: allSpells[0],
-				sources: allSpells[0].sources,
-				school: allSpells[0].school,
-				tags: allSpells[0].tags
-			});
-		}
-
+		const eligibleSlots = effectiveActiveSlot ? [effectiveActiveSlot] : spellSlots;
 		const filtered = allSpells.filter((spell) =>
-			matchesGlobalMagicProfile(spell, globalMagicProfile)
+			eligibleSlots.some((slot) => matchesSpellSlot(spell, slot, globalMagicProfile))
 		);
 
 		debug.spells('Filtered spells result', { count: filtered.length, total: allSpells.length });
 		return filtered;
-	}, [classData, globalMagicProfile, calculationResult, state.classId]);
+	}, [classData, globalMagicProfile, calculationResult, spellSlots, state.classId, effectiveActiveSlot]);
 
 	const spellCount = useMemo(() => {
 		return spellSlots.length;
@@ -195,36 +258,8 @@ const Spells: React.FC = () => {
 		// Filter by sustained
 		spells = spells.filter((spell) => matchesSpellSustained(spell, sustainedFilter));
 
-		// --- Smart Slot Filtering (M3.20) ---
-		if (activeSlotId) {
-			const activeSlot = spellSlots.find((s) => s.id === activeSlotId);
-			if (activeSlot) {
-				spells = spells.filter((spell) => {
-					// 1. Check Specific Restrictions
-					if (!matchesSpellRestrictions(spell, activeSlot.specificRestrictions)) return false;
-
-					// 3. Check Global Profile (if the slot is global)
-					if (activeSlot.isGlobal && globalMagicProfile) {
-						return matchesGlobalMagicProfile(spell, globalMagicProfile);
-					}
-
-					return true;
-				});
-			}
-		}
-
 		return spells;
-	}, [
-		availableSpells,
-		sourceFilter,
-		schoolFilter,
-		tagFilter,
-		costFilter,
-		sustainedFilter,
-		activeSlotId,
-		spellSlots,
-		globalMagicProfile
-	]);
+	}, [availableSpells, sourceFilter, schoolFilter, tagFilter, costFilter, sustainedFilter]);
 
 	// Handle spell selection with Smart Allocation (M3.20)
 	const handleSpellToggle = (spellId: string) => {
@@ -252,18 +287,26 @@ const Spells: React.FC = () => {
 			if (existingSlotId) {
 				delete newSelected[existingSlotId];
 				debug.spells('Spell deselected', { spellId, slotId: existingSlotId });
+				setIsManualSlotOverride(false);
+				setActiveSlotId(existingSlotId);
 				return newSelected;
 			}
 
-			// 2. If it's a specific slot click, target that slot
-			if (activeSlotId) {
-				const slot = spellSlots.find((s) => s.id === activeSlotId);
-				if (slot) {
-					newSelected[activeSlotId] = spellId;
-					debug.spells('Spell selected', { spellId, slotId: activeSlotId });
-					setActiveSlotId(null); // Close active slot after selection
+			// 2. Fill the active cursor slot. Users can override the cursor by clicking any slot.
+			if (effectiveActiveSlot) {
+				if (matchesSpellSlot(spell, effectiveActiveSlot, globalMagicProfile)) {
+					newSelected[effectiveActiveSlot.id] = spellId;
+					debug.spells('Spell selected', { spellId, slotId: effectiveActiveSlot.id });
+					setIsManualSlotOverride(false);
+					setActiveSlotId(getNextEmptySlotId(spellSlots, newSelected, effectiveActiveSlot.id));
 					return newSelected;
 				}
+
+				debug.warn('Spells', 'Spell does not match active slot', {
+					spellId,
+					slotId: effectiveActiveSlot.id
+				});
+				return prev;
 			}
 
 			// 3. Smart Allocation: Find the best empty slot
@@ -271,22 +314,15 @@ const Spells: React.FC = () => {
 			const emptySlots = spellSlots
 				.filter((s) => !newSelected[s.id])
 				.sort((a, b) => {
-					// More restrictions = higher priority
-					const aRes = (a.specificRestrictions ? 10 : 0) + (a.isGlobal ? 0 : 5);
-					const bRes = (b.specificRestrictions ? 10 : 0) + (b.isGlobal ? 0 : 5);
-					return bRes - aRes;
+					return getSlotRestrictionWeight(b) - getSlotRestrictionWeight(a);
 				});
 
 			for (const slot of emptySlots) {
-				// Restriction check
-				let fitsRestrictions = true;
-				if (slot.specificRestrictions) {
-					fitsRestrictions = matchesSpellRestrictions(spell, slot.specificRestrictions);
-				}
-
-				if (fitsRestrictions) {
+				if (matchesSpellSlot(spell, slot, globalMagicProfile)) {
 					newSelected[slot.id] = spellId;
 					debug.spells('Spell auto-allocated', { spellId, slotId: slot.id });
+					setIsManualSlotOverride(false);
+					setActiveSlotId(getNextEmptySlotId(spellSlots, newSelected, slot.id));
 					return newSelected;
 				}
 			}
@@ -565,7 +601,7 @@ const Spells: React.FC = () => {
 
 							{/* Cost Filter */}
 							<FilterGroup>
-								<FilterLabel>Type/Cost</FilterLabel>
+								<FilterLabel>Cost</FilterLabel>
 								<select
 									value={costFilter}
 									onChange={(e) => setCostFilter(e.target.value as CostFilter)}
@@ -623,6 +659,7 @@ const Spells: React.FC = () => {
 					>
 						<span>
 							Showing {filteredSpells.length} of {availableSpells.length} available spells
+							{effectiveActiveSlot ? ` for ${effectiveActiveSlot.sourceName}` : ''}
 						</span>
 						<span
 							style={{
@@ -657,7 +694,7 @@ const Spells: React.FC = () => {
 									const assignedSpell = assignedSpellId
 										? allSpells.find((s) => s.id === assignedSpellId)
 										: null;
-									const isActive = activeSlotId === slot.id;
+									const isActive = effectiveActiveSlot?.id === slot.id;
 
 									return (
 										<div
@@ -669,7 +706,10 @@ const Spells: React.FC = () => {
 													: 'border-border bg-card/60 hover:border-primary/40',
 												assignedSpell ? 'border-primary/40' : 'border-dashed opacity-80'
 											)}
-											onClick={() => setActiveSlotId(isActive ? null : slot.id)}
+											onClick={() => {
+												setIsManualSlotOverride(true);
+												setActiveSlotId(slot.id);
+											}}
 										>
 											<div className="flex items-center gap-2 overflow-hidden">
 												{assignedSpell ? (
@@ -699,18 +739,21 @@ const Spells: React.FC = () => {
 							<h3 className="font-cinzel mb-3 text-2xl text-white">No Matching Spells</h3>
 							<p className="text-muted-foreground mx-auto max-w-sm text-base leading-relaxed">
 								{activeSlotId
-									? 'This pocket has specific restrictions that no spells in our library currently meet.'
+									? 'This slot has restrictions that no spells in the current result set meet.'
 									: 'None of your available spells match the active filters.'}
 							</p>
-							{activeSlotId && (
+							{effectiveActiveSlot && nextEmptySlotId && nextEmptySlotId !== effectiveActiveSlot.id && (
 								<SecondaryButton
 									style={{
 										fontFamily: 'Cinzel, serif',
 										marginTop: theme.spacing[6]
 									}}
-									onClick={() => setActiveSlotId(null)}
+									onClick={() => {
+										setIsManualSlotOverride(false);
+										setActiveSlotId(nextEmptySlotId);
+									}}
 								>
-									Browse All Class Spells
+									Target Next Empty Slot
 								</SecondaryButton>
 							)}
 						</div>

--- a/src/styles/App.styles.ts
+++ b/src/styles/App.styles.ts
@@ -71,5 +71,19 @@ export const FixedAuthStatus = styled.div`
 	display: flex;
 	flex-direction: row;
 	align-items: center;
+	justify-content: flex-end;
 	gap: 0.5rem;
+	max-width: calc(100vw - 2rem);
+
+	& > * {
+		flex: 0 0 auto;
+	}
+
+	@media (max-width: 480px) {
+		top: 0.5rem;
+		right: 0.5rem;
+		padding: 0.375rem;
+		gap: 0.375rem;
+		max-width: calc(100vw - 1rem);
+	}
 `;


### PR DESCRIPTION
## Summary

Fixes the likely persistence failure behind issue #129 by normalizing partial legacy `characterState` data before Convex character writes.

Root cause: legacy/current-upgrade records can carry incomplete nested runtime state, especially `characterState.resources.current` and inventory currency. localStorage tolerated that shape, but Convex table validators require complete nested fields, causing `characters:create` to fail during final save or current-rules draft creation.

## Changes

1. Added `normalizeCharacterStateForStorage()` as the shared boundary normalizer.
2. Routed Convex character saves through that normalizer before mutation.
3. Added regression coverage for partial legacy runtime state.
4. Updated the storage and versioning system docs.

## Preview

Vercel preview: https://dc20clean-1x66anugl-yasafs-projects.vercel.app
Branch alias: https://dc20clean-git-codex-fix-issue-129-convex-state-yasafs-projects.vercel.app

## Validation

1. `npm run test:unit -- --run src/lib/utils/storageUtils.spec.tsx src/lib/rulesdata/versioning/characterUpgrade.test.ts` passed.
2. `git diff --check` passed.
3. Deployed preview reached `READY` for commit `92c0ab3e00c0dbcb224caec0bc2b38b3c506274e`.
4. Browser smoke against protected Vercel preview passed: `/create-character` loaded with title `DC20 Character Creator` and no captured console warnings/errors.
5. `npm run e2e:agentic:smoke` passed: 3/3 agentic character creation recipes.
6. `PLAYWRIGHT_SKIP_BUILD=1 npm run test:e2e -- --project=desktop e2e/13-character-upgrade.e2e.spec.ts` partially passed: the current-version-copy upgrade test passed; the unsupported-version blocker test timed out because the UI button label is now `Review update blockers` while the test expects `Review upgrade blockers`. That selector drift appears unrelated to this fix.