### PR TITLE
feat(equipment): add searchable editable saved equipment

### DIFF
--- a/docs/TODO_REVIEW.md
+++ b/docs/TODO_REVIEW.md
@@ -36,7 +36,7 @@
 7. **[Complete] Equipment preset search/filter — 82/100**
    1. Source: `EQUIPMENT_SYSTEM.MD` section 10.
    2. Requirements completed: client-side name/type/property filter, no schema change, empty-state copy, and mobile-compatible controls.
-8. **[Ready] Equipment duplicate/clone — 80/100**
+8. **[Complete] Equipment duplicate/clone — 80/100**
    1. Source: `EQUIPMENT_SYSTEM.MD` section 10.
    2. Requirements completed: generate a new ID and timestamps, append `Copy` to the name, preserve mechanical fields, and open the duplicate for editing without mutating the source.
 

--- a/docs/TODO_REVIEW.md
+++ b/docs/TODO_REVIEW.md
@@ -33,7 +33,7 @@
 6. **[Ready] Cleric Dark/Knowledge domain E2E — 84/100**
    1. Source: `TESTING_SYSTEM.MD` section 6.
    2. Requirements are already explicit. Keep rule permutations in unit tests and use E2E only for creation, persistence, and sheet visibility.
-7. **[Ready] Equipment preset search/filter — 82/100**
+7. **[Complete] Equipment preset search/filter — 82/100**
    1. Source: `EQUIPMENT_SYSTEM.MD` section 10.
    2. Requirements completed: client-side name/type/property filter, no schema change, empty-state copy, and mobile-compatible controls.
 8. **[Ready] Equipment duplicate/clone — 80/100**

--- a/docs/TODO_REVIEW.md
+++ b/docs/TODO_REVIEW.md
@@ -48,7 +48,7 @@
 4. **MSL/SSL in-play enhancement workflow — 72/100**: calculator limits exist; performed-action state and declare-before-roll interaction are not modeled.
 5. **Populate `EffectResolution` spell data — 70/100**: schema exists; source mapping and completeness acceptance need an audit report.
 6. **Populate ancestry `TraitRequirements` — 70/100**: schema exists; source mapping and choice-restriction semantics need an audit report.
-7. **Edit saved custom equipment — 68/100**: persistence exists; overwrite-versus-save-copy behavior needs a decision.
+7. **[Complete] Edit saved custom equipment — 68/100**: edits preserve the stable item ID; duplication remains the explicit save-copy path.
 8. **Ancestry/traits subsystem split — 65/100**: desired boundary is documented; migration sequence and measurable payoff are not.
 9. **Agentic QA next slice — 62/100**: tasks are listed; required gate policy, runtime budget, and CI ownership remain undecided.
 

--- a/docs/systems/EQUIPMENT_SYSTEM.MD
+++ b/docs/systems/EQUIPMENT_SYSTEM.MD
@@ -447,6 +447,8 @@ importEquipmentFromJson(json: string): { success: boolean; error?: string }
 - Delete individual items
 - Export all to JSON
 - Import from JSON file
+- Duplicate any saved item as an independent `Copy`; the source remains unchanged and
+  the duplicate receives a new ID and timestamps.
 
 ### Preset Search
 
@@ -461,7 +463,7 @@ without a separate modal.
 
 - [ ] Integration with character creation (equip custom items)
 - [ ] Edit existing saved equipment
-- [ ] Duplicate/clone functionality
+- [x] Duplicate/clone functionality
 - [x] Search/filter presets
 - [ ] Mobile-optimized layout
 - [ ] Share equipment via URL/code

--- a/docs/systems/EQUIPMENT_SYSTEM.MD
+++ b/docs/systems/EQUIPMENT_SYSTEM.MD
@@ -449,6 +449,8 @@ importEquipmentFromJson(json: string): { success: boolean; error?: string }
 - Import from JSON file
 - Duplicate any saved item as an independent `Copy`; the source remains unchanged and
   the duplicate receives a new ID and timestamps.
+- Edit any saved item in its category builder. Saving preserves the stable item ID and
+  creation timestamp while refreshing its mechanical effects and update timestamp.
 
 ### Preset Search
 
@@ -462,7 +464,7 @@ without a separate modal.
 ## 10. Future Enhancements
 
 - [ ] Integration with character creation (equip custom items)
-- [ ] Edit existing saved equipment
+- [x] Edit existing saved equipment
 - [x] Duplicate/clone functionality
 - [x] Search/filter presets
 - [ ] Mobile-optimized layout

--- a/docs/systems/EQUIPMENT_SYSTEM.MD
+++ b/docs/systems/EQUIPMENT_SYSTEM.MD
@@ -2,7 +2,7 @@
 
 > Purpose: Central reference for custom equipment creation, data models, validation rules, storage, and UI flows.
 > Status: Active
-> Last Updated: 2026-06-23
+> Last Updated: 2026-07-13
 >
 > **Menu Entry:** "Equipage" in Reference Tools section
 
@@ -448,6 +448,13 @@ importEquipmentFromJson(json: string): { success: boolean; error?: string }
 - Export all to JSON
 - Import from JSON file
 
+### Preset Search
+
+All four builders expose client-side preset search on the first step. Search matches
+all entered tokens across preset names, equipment type, properties, and weapon styles.
+Weapon search replaces the former 12-item truncation, so every preset is selectable
+without a separate modal.
+
 ---
 
 ## 10. Future Enhancements
@@ -455,7 +462,7 @@ importEquipmentFromJson(json: string): { success: boolean; error?: string }
 - [ ] Integration with character creation (equip custom items)
 - [ ] Edit existing saved equipment
 - [ ] Duplicate/clone functionality
-- [ ] Search/filter presets
+- [x] Search/filter presets
 - [ ] Mobile-optimized layout
 - [ ] Share equipment via URL/code
 

--- a/src/lib/rulesdata/equipment/storage/equipmentStorage.test.ts
+++ b/src/lib/rulesdata/equipment/storage/equipmentStorage.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { EQUIPMENT_RULES_VERSION } from '../schemas/baseEquipment';
 import {
 	exportEquipmentToJson,
+	duplicateCustomEquipment,
 	getAllCustomWeapons,
 	importEquipmentFromJson,
 	saveCustomWeapon
@@ -84,5 +85,41 @@ describe('custom equipment storage compatibility', () => {
 
 		// eslint-disable-next-line no-restricted-syntax
 		expect(JSON.parse(exportEquipmentToJson()).rulesVersion).toBe(EQUIPMENT_RULES_VERSION);
+	});
+
+	it('duplicates an item without changing the source', () => {
+		const weapon = {
+			id: 'source-sword',
+			name: 'Source Sword',
+			category: 'weapon',
+			weaponType: 'melee',
+			style: 'sword',
+			damageType: 'slashing',
+			baseDamage: 1,
+			finalDamage: 2,
+			range: '1',
+			properties: ['heavy'],
+			pointsSpent: 2,
+			maxPoints: 2,
+			isPreset: true,
+			presetOrigin: 'greatsword',
+			createdAt: '2026-06-13T00:00:00.000Z',
+			updatedAt: '2026-06-13T00:00:00.000Z'
+		} as Parameters<typeof saveCustomWeapon>[0];
+		saveCustomWeapon(weapon);
+
+		const duplicate = duplicateCustomEquipment('weapon', weapon.id);
+		const saved = getAllCustomWeapons();
+
+		expect(saved).toHaveLength(2);
+		expect(saved[0]).toMatchObject({ id: weapon.id, name: weapon.name, isPreset: true });
+		expect(duplicate).toMatchObject({
+			name: 'Source Sword Copy',
+			isPreset: false,
+			properties: ['heavy'],
+			finalDamage: 2,
+			presetOrigin: 'greatsword'
+		});
+		expect(duplicate?.id).not.toBe(weapon.id);
 	});
 });

--- a/src/lib/rulesdata/equipment/storage/equipmentStorage.ts
+++ b/src/lib/rulesdata/equipment/storage/equipmentStorage.ts
@@ -264,6 +264,33 @@ export function deleteCustomEquipment(category: string, id: string): void {
 	}
 }
 
+export function duplicateCustomEquipment(
+	category: CustomEquipment['category'],
+	id: string
+): CustomEquipment | undefined {
+	const source = getAllCustomEquipment().find(
+		(equipment) => equipment.category === category && equipment.id === id
+	);
+	if (!source) return undefined;
+
+	const timestamp = new Date().toISOString();
+	const uniqueId =
+		typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+			? crypto.randomUUID()
+			: `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+	const duplicate = {
+		...source,
+		id: `custom-${category}-copy-${uniqueId}`,
+		name: `${source.name} Copy`,
+		isPreset: false,
+		createdAt: timestamp,
+		updatedAt: timestamp
+	} as CustomEquipment;
+
+	saveCustomEquipment(duplicate);
+	return duplicate;
+}
+
 // ================================================================= //
 // EXPORT / IMPORT
 // ================================================================= //

--- a/src/routes/custom-equipment/CustomEquipment.tsx
+++ b/src/routes/custom-equipment/CustomEquipment.tsx
@@ -26,6 +26,7 @@ import ArmorBuilder from './components/ArmorBuilder';
 import ShieldBuilder from './components/ShieldBuilder';
 import SpellFocusBuilder from './components/SpellFocusBuilder';
 import SavedEquipmentList from './components/SavedEquipmentList';
+import type { CustomEquipment as CustomEquipmentData } from '../../lib/rulesdata/equipment/schemas';
 
 // Category icons
 const CATEGORY_ICONS: Record<EquipmentCategory, string> = {
@@ -41,21 +42,60 @@ const CustomEquipment: React.FC = () => {
 	const { t } = useTranslation();
 	const [activeTab, setActiveTab] = useState<TabType>('create');
 	const [selectedCategory, setSelectedCategory] = useState<EquipmentCategory | null>(null);
+	const [editingEquipment, setEditingEquipment] = useState<CustomEquipmentData | null>(null);
 
 	const handleCategorySelect = (category: EquipmentCategory) => {
+		setEditingEquipment(null);
 		setSelectedCategory(category);
+	};
+
+	const closeBuilder = () => {
+		setEditingEquipment(null);
+		setSelectedCategory(null);
+	};
+
+	const handleEdit = (equipment: CustomEquipmentData) => {
+		setEditingEquipment(equipment);
+		setSelectedCategory(equipment.category);
+		setActiveTab('create');
 	};
 
 	const renderBuilder = () => {
 		switch (selectedCategory) {
 			case 'weapon':
-				return <WeaponBuilder onBack={() => setSelectedCategory(null)} />;
+				return (
+					<WeaponBuilder
+						onBack={closeBuilder}
+						initialEquipment={
+							editingEquipment?.category === 'weapon' ? editingEquipment : undefined
+						}
+					/>
+				);
 			case 'armor':
-				return <ArmorBuilder onBack={() => setSelectedCategory(null)} />;
+				return (
+					<ArmorBuilder
+						onBack={closeBuilder}
+						initialEquipment={editingEquipment?.category === 'armor' ? editingEquipment : undefined}
+					/>
+				);
 			case 'shield':
-				return <ShieldBuilder onBack={() => setSelectedCategory(null)} />;
+				return (
+					<ShieldBuilder
+						onBack={closeBuilder}
+						initialEquipment={
+							editingEquipment?.category === 'shield' ? editingEquipment : undefined
+						}
+					/>
+				);
 			case 'spellFocus':
-				return <SpellFocusBuilder onBack={() => setSelectedCategory(null)} />;
+				return (
+					<SpellFocusBuilder
+						onBack={closeBuilder}
+						initialEquipment={
+							editingEquipment?.category === 'spellFocus' ? editingEquipment : undefined
+						}
+					/>
+				);
 			default:
 				return null;
 		}
@@ -106,7 +146,7 @@ const CustomEquipment: React.FC = () => {
 
 				{activeTab === 'create' && selectedCategory && renderBuilder()}
 
-				{activeTab === 'saved' && <SavedEquipmentList />}
+				{activeTab === 'saved' && <SavedEquipmentList onEdit={handleEdit} />}
 			</MainContent>
 		</PageContainer>
 	);

--- a/src/routes/custom-equipment/components/ArmorBuilder.tsx
+++ b/src/routes/custom-equipment/components/ArmorBuilder.tsx
@@ -14,6 +14,8 @@ import { validateArmor } from '../../../lib/rulesdata/equipment/validation/equip
 import { saveCustomArmor } from '../../../lib/rulesdata/equipment/storage/equipmentStorage';
 import { withEquipmentEffects } from '../../../lib/rulesdata/equipment/equipmentEffects';
 import type { CustomArmor, ArmorType } from '../../../lib/rulesdata/equipment/schemas/armorSchema';
+import { filterEquipmentPresets } from '../presetSearch';
+import PresetSearchInput from './PresetSearchInput';
 import {
 	BuilderContainer,
 	SectionTitle,
@@ -46,6 +48,7 @@ const ArmorBuilder: React.FC<ArmorBuilderProps> = ({ onBack }) => {
 	const [selectedProperties, setSelectedProperties] = useState<string[]>([]);
 	const [name, setName] = useState('');
 	const [selectedPreset, setSelectedPreset] = useState<string | null>(null);
+	const [presetQuery, setPresetQuery] = useState('');
 
 	const maxPoints = 2;
 
@@ -61,6 +64,16 @@ const ArmorBuilder: React.FC<ArmorBuilderProps> = ({ onBack }) => {
 		if (!armorType) return [];
 		return getPropertiesForArmorType(armorType);
 	}, [armorType]);
+
+	const filteredPresets = useMemo(
+		() =>
+			filterEquipmentPresets(PRESET_ARMOR, presetQuery, (preset) => [
+				preset.name,
+				preset.armorType,
+				...(preset.hasPdr ? ['pdr'] : [])
+			]),
+		[presetQuery]
+	);
 
 	const validation = useMemo(() => {
 		if (!armorType) return { isValid: false, errors: [], warnings: [] };
@@ -228,8 +241,13 @@ const ArmorBuilder: React.FC<ArmorBuilderProps> = ({ onBack }) => {
 
 					<div className="mb-6">
 						<h4 className="mb-3 text-sm font-semibold text-gray-400">Or Load a Preset</h4>
+						<PresetSearchInput
+							value={presetQuery}
+							onChange={setPresetQuery}
+							resultCount={filteredPresets.length}
+						/>
 						<OptionGrid>
-							{PRESET_ARMOR.map((preset) => (
+							{filteredPresets.map((preset) => (
 								<OptionCard
 									key={preset.id}
 									$selected={selectedPreset === preset.id}
@@ -247,6 +265,9 @@ const ArmorBuilder: React.FC<ArmorBuilderProps> = ({ onBack }) => {
 								</OptionCard>
 							))}
 						</OptionGrid>
+						{filteredPresets.length === 0 && (
+							<p className="py-4 text-center text-sm text-gray-500">No armor presets match.</p>
+						)}
 					</div>
 
 					<ActionButtons>

--- a/src/routes/custom-equipment/components/ArmorBuilder.tsx
+++ b/src/routes/custom-equipment/components/ArmorBuilder.tsx
@@ -40,14 +40,19 @@ import {
 
 interface ArmorBuilderProps {
 	onBack: () => void;
+	initialEquipment?: CustomArmor;
 }
 
-const ArmorBuilder: React.FC<ArmorBuilderProps> = ({ onBack }) => {
+const ArmorBuilder: React.FC<ArmorBuilderProps> = ({ onBack, initialEquipment }) => {
 	const [step, setStep] = useState(1);
-	const [armorType, setArmorType] = useState<ArmorType | null>(null);
-	const [selectedProperties, setSelectedProperties] = useState<string[]>([]);
-	const [name, setName] = useState('');
-	const [selectedPreset, setSelectedPreset] = useState<string | null>(null);
+	const [armorType, setArmorType] = useState<ArmorType | null>(initialEquipment?.armorType ?? null);
+	const [selectedProperties, setSelectedProperties] = useState<string[]>(
+		initialEquipment?.properties ?? []
+	);
+	const [name, setName] = useState(initialEquipment?.name ?? '');
+	const [selectedPreset, setSelectedPreset] = useState<string | null>(
+		initialEquipment?.presetOrigin ?? null
+	);
 	const [presetQuery, setPresetQuery] = useState('');
 
 	const maxPoints = 2;
@@ -165,8 +170,9 @@ const ArmorBuilder: React.FC<ArmorBuilderProps> = ({ onBack }) => {
 		const stats = calculateStats();
 		const armorTypeData = ARMOR_TYPES.find((t) => t.id === armorType);
 
+		const now = new Date().toISOString();
 		const armor: CustomArmor = {
-			id: `custom-armor-${Date.now()}`,
+			id: initialEquipment?.id ?? `custom-armor-${Date.now()}`,
 			category: 'armor',
 			name: name || 'Custom Armor',
 			armorType: armorType!,
@@ -181,8 +187,8 @@ const ArmorBuilder: React.FC<ArmorBuilderProps> = ({ onBack }) => {
 			hasAgilityDisadvantage: armorType === 'heavy' || stats.hasRigid,
 			isPreset: !!selectedPreset,
 			presetOrigin: selectedPreset || undefined,
-			createdAt: new Date().toISOString(),
-			updatedAt: new Date().toISOString()
+			createdAt: initialEquipment?.createdAt ?? now,
+			updatedAt: now
 		};
 
 		return withEquipmentEffects(armor);

--- a/src/routes/custom-equipment/components/PresetSearchInput.tsx
+++ b/src/routes/custom-equipment/components/PresetSearchInput.tsx
@@ -1,0 +1,30 @@
+interface PresetSearchInputProps {
+	value: string;
+	onChange: (value: string) => void;
+	resultCount: number;
+}
+
+export default function PresetSearchInput({
+	value,
+	onChange,
+	resultCount
+}: PresetSearchInputProps) {
+	return (
+		<div className="mb-3">
+			<label className="sr-only" htmlFor="equipment-preset-search">
+				Search presets
+			</label>
+			<input
+				id="equipment-preset-search"
+				type="search"
+				value={value}
+				onChange={(event) => onChange(event.target.value)}
+				placeholder="Search presets by name, type, or property"
+				className="w-full rounded-md border border-slate-600 bg-slate-900 px-3 py-2 text-sm text-white placeholder:text-slate-500 focus:border-amber-400 focus:outline-none"
+			/>
+			<div className="mt-1 text-xs text-gray-500">
+				{resultCount} {resultCount === 1 ? 'preset' : 'presets'}
+			</div>
+		</div>
+	);
+}

--- a/src/routes/custom-equipment/components/SavedEquipmentList.tsx
+++ b/src/routes/custom-equipment/components/SavedEquipmentList.tsx
@@ -14,6 +14,7 @@ import {
 	deleteCustomArmor,
 	deleteCustomShield,
 	deleteCustomSpellFocus,
+	duplicateCustomEquipment,
 	exportEquipmentToJson,
 	importEquipmentFromJson
 } from '../../../lib/rulesdata/equipment/storage/equipmentStorage';
@@ -112,6 +113,10 @@ const SavedEquipmentList: React.FC = () => {
 	};
 
 	const totalCount = weapons.length + armor.length + shields.length + spellFocuses.length;
+	const handleDuplicate = (category: 'weapon' | 'armor' | 'shield' | 'spellFocus', id: string) => {
+		duplicateCustomEquipment(category, id);
+		loadData();
+	};
 
 	const renderWeaponCard = (weapon: CustomWeapon) => (
 		<SavedItemCard key={weapon.id}>
@@ -144,7 +149,10 @@ const SavedEquipmentList: React.FC = () => {
 					<span className="text-xs text-gray-500">+{weapon.properties.length - 4}</span>
 				)}
 			</div>
-			<div className="flex justify-end">
+			<div className="flex justify-end gap-2">
+				<Button variant="outline" size="sm" onClick={() => handleDuplicate('weapon', weapon.id)}>
+					Duplicate
+				</Button>
 				<Button
 					variant="ghost"
 					size="sm"
@@ -177,7 +185,10 @@ const SavedEquipmentList: React.FC = () => {
 				{item.hasPdr && <Badge variant="secondary">PDR</Badge>}
 				{item.hasEdr && <Badge variant="secondary">EDR</Badge>}
 			</div>
-			<div className="flex justify-end">
+			<div className="flex justify-end gap-2">
+				<Button variant="outline" size="sm" onClick={() => handleDuplicate('armor', item.id)}>
+					Duplicate
+				</Button>
 				<Button
 					variant="ghost"
 					size="sm"
@@ -217,7 +228,10 @@ const SavedEquipmentList: React.FC = () => {
 					</Badge>
 				))}
 			</div>
-			<div className="flex justify-end">
+			<div className="flex justify-end gap-2">
+				<Button variant="outline" size="sm" onClick={() => handleDuplicate('shield', item.id)}>
+					Duplicate
+				</Button>
 				<Button
 					variant="ghost"
 					size="sm"
@@ -261,7 +275,10 @@ const SavedEquipmentList: React.FC = () => {
 					<Badge variant="secondary">Long Range +{item.longRangeBonus}</Badge>
 				)}
 			</div>
-			<div className="flex justify-end">
+			<div className="flex justify-end gap-2">
+				<Button variant="outline" size="sm" onClick={() => handleDuplicate('spellFocus', item.id)}>
+					Duplicate
+				</Button>
 				<Button
 					variant="ghost"
 					size="sm"

--- a/src/routes/custom-equipment/components/SavedEquipmentList.tsx
+++ b/src/routes/custom-equipment/components/SavedEquipmentList.tsx
@@ -34,7 +34,11 @@ import {
 
 type FilterType = 'all' | 'weapon' | 'armor' | 'shield' | 'spellFocus';
 
-const SavedEquipmentList: React.FC = () => {
+interface SavedEquipmentListProps {
+	onEdit: (equipment: CustomWeapon | CustomArmor | CustomShield | CustomSpellFocus) => void;
+}
+
+const SavedEquipmentList: React.FC<SavedEquipmentListProps> = ({ onEdit }) => {
 	const [filter, setFilter] = useState<FilterType>('all');
 	const [weapons, setWeapons] = useState<CustomWeapon[]>([]);
 	const [armor, setArmor] = useState<CustomArmor[]>([]);
@@ -150,6 +154,9 @@ const SavedEquipmentList: React.FC = () => {
 				)}
 			</div>
 			<div className="flex justify-end gap-2">
+				<Button variant="outline" size="sm" onClick={() => onEdit(weapon)}>
+					Edit
+				</Button>
 				<Button variant="outline" size="sm" onClick={() => handleDuplicate('weapon', weapon.id)}>
 					Duplicate
 				</Button>
@@ -186,6 +193,9 @@ const SavedEquipmentList: React.FC = () => {
 				{item.hasEdr && <Badge variant="secondary">EDR</Badge>}
 			</div>
 			<div className="flex justify-end gap-2">
+				<Button variant="outline" size="sm" onClick={() => onEdit(item)}>
+					Edit
+				</Button>
 				<Button variant="outline" size="sm" onClick={() => handleDuplicate('armor', item.id)}>
 					Duplicate
 				</Button>
@@ -229,6 +239,9 @@ const SavedEquipmentList: React.FC = () => {
 				))}
 			</div>
 			<div className="flex justify-end gap-2">
+				<Button variant="outline" size="sm" onClick={() => onEdit(item)}>
+					Edit
+				</Button>
 				<Button variant="outline" size="sm" onClick={() => handleDuplicate('shield', item.id)}>
 					Duplicate
 				</Button>
@@ -276,6 +289,9 @@ const SavedEquipmentList: React.FC = () => {
 				)}
 			</div>
 			<div className="flex justify-end gap-2">
+				<Button variant="outline" size="sm" onClick={() => onEdit(item)}>
+					Edit
+				</Button>
 				<Button variant="outline" size="sm" onClick={() => handleDuplicate('spellFocus', item.id)}>
 					Duplicate
 				</Button>

--- a/src/routes/custom-equipment/components/ShieldBuilder.tsx
+++ b/src/routes/custom-equipment/components/ShieldBuilder.tsx
@@ -18,6 +18,8 @@ import type {
 	CustomShield,
 	ShieldType
 } from '../../../lib/rulesdata/equipment/schemas/shieldSchema';
+import { filterEquipmentPresets } from '../presetSearch';
+import PresetSearchInput from './PresetSearchInput';
 import {
 	BuilderContainer,
 	SectionTitle,
@@ -50,6 +52,7 @@ const ShieldBuilder: React.FC<ShieldBuilderProps> = ({ onBack }) => {
 	const [selectedProperties, setSelectedProperties] = useState<string[]>([]);
 	const [name, setName] = useState('');
 	const [selectedPreset, setSelectedPreset] = useState<string | null>(null);
+	const [presetQuery, setPresetQuery] = useState('');
 
 	const maxPoints = 2;
 
@@ -65,6 +68,16 @@ const ShieldBuilder: React.FC<ShieldBuilderProps> = ({ onBack }) => {
 		if (!shieldType) return [];
 		return getPropertiesForShieldType(shieldType);
 	}, [shieldType]);
+
+	const filteredPresets = useMemo(
+		() =>
+			filterEquipmentPresets(PRESET_SHIELDS, presetQuery, (preset) => [
+				preset.name,
+				preset.shieldType,
+				...preset.properties
+			]),
+		[presetQuery]
+	);
 
 	const validation = useMemo(() => {
 		if (!shieldType) return { isValid: false, errors: [], warnings: [] };
@@ -240,8 +253,13 @@ const ShieldBuilder: React.FC<ShieldBuilderProps> = ({ onBack }) => {
 
 					<div className="mb-6">
 						<h4 className="mb-3 text-sm font-semibold text-gray-400">Or Load a Preset</h4>
+						<PresetSearchInput
+							value={presetQuery}
+							onChange={setPresetQuery}
+							resultCount={filteredPresets.length}
+						/>
 						<OptionGrid>
-							{PRESET_SHIELDS.map((preset) => (
+							{filteredPresets.map((preset) => (
 								<OptionCard
 									key={preset.id}
 									$selected={selectedPreset === preset.id}
@@ -263,6 +281,9 @@ const ShieldBuilder: React.FC<ShieldBuilderProps> = ({ onBack }) => {
 								</OptionCard>
 							))}
 						</OptionGrid>
+						{filteredPresets.length === 0 && (
+							<p className="py-4 text-center text-sm text-gray-500">No shield presets match.</p>
+						)}
 					</div>
 
 					<ActionButtons>

--- a/src/routes/custom-equipment/components/ShieldBuilder.tsx
+++ b/src/routes/custom-equipment/components/ShieldBuilder.tsx
@@ -44,14 +44,21 @@ import {
 
 interface ShieldBuilderProps {
 	onBack: () => void;
+	initialEquipment?: CustomShield;
 }
 
-const ShieldBuilder: React.FC<ShieldBuilderProps> = ({ onBack }) => {
+const ShieldBuilder: React.FC<ShieldBuilderProps> = ({ onBack, initialEquipment }) => {
 	const [step, setStep] = useState(1);
-	const [shieldType, setShieldType] = useState<ShieldType | null>(null);
-	const [selectedProperties, setSelectedProperties] = useState<string[]>([]);
-	const [name, setName] = useState('');
-	const [selectedPreset, setSelectedPreset] = useState<string | null>(null);
+	const [shieldType, setShieldType] = useState<ShieldType | null>(
+		initialEquipment?.shieldType ?? null
+	);
+	const [selectedProperties, setSelectedProperties] = useState<string[]>(
+		initialEquipment?.properties ?? []
+	);
+	const [name, setName] = useState(initialEquipment?.name ?? '');
+	const [selectedPreset, setSelectedPreset] = useState<string | null>(
+		initialEquipment?.presetOrigin ?? null
+	);
 	const [presetQuery, setPresetQuery] = useState('');
 
 	const maxPoints = 2;
@@ -172,8 +179,9 @@ const ShieldBuilder: React.FC<ShieldBuilderProps> = ({ onBack }) => {
 	const buildShield = (): CustomShield => {
 		const stats = calculateStats();
 
+		const now = new Date().toISOString();
 		const shield: CustomShield = {
-			id: `custom-shield-${Date.now()}`,
+			id: initialEquipment?.id ?? `custom-shield-${Date.now()}`,
 			category: 'shield',
 			name: name || 'Custom Shield',
 			shieldType: shieldType!,
@@ -188,8 +196,8 @@ const ShieldBuilder: React.FC<ShieldBuilderProps> = ({ onBack }) => {
 			hasAgilityDisadvantage: shieldType === 'heavy' || stats.hasRigid,
 			isPreset: !!selectedPreset,
 			presetOrigin: selectedPreset || undefined,
-			createdAt: new Date().toISOString(),
-			updatedAt: new Date().toISOString()
+			createdAt: initialEquipment?.createdAt ?? now,
+			updatedAt: now
 		};
 
 		return withEquipmentEffects(shield);

--- a/src/routes/custom-equipment/components/SpellFocusBuilder.tsx
+++ b/src/routes/custom-equipment/components/SpellFocusBuilder.tsx
@@ -18,6 +18,8 @@ import type {
 	CustomSpellFocus,
 	SpellFocusHands
 } from '../../../lib/rulesdata/equipment/schemas/spellFocusSchema';
+import { filterEquipmentPresets } from '../presetSearch';
+import PresetSearchInput from './PresetSearchInput';
 import {
 	BuilderContainer,
 	SectionTitle,
@@ -50,6 +52,7 @@ const SpellFocusBuilder: React.FC<SpellFocusBuilderProps> = ({ onBack }) => {
 	const [selectedProperties, setSelectedProperties] = useState<string[]>([]);
 	const [name, setName] = useState('');
 	const [selectedPreset, setSelectedPreset] = useState<string | null>(null);
+	const [presetQuery, setPresetQuery] = useState('');
 
 	const maxPoints = useMemo(() => getMaxPointsForSpellFocus(hands === 'two-handed'), [hands]);
 
@@ -63,6 +66,16 @@ const SpellFocusBuilder: React.FC<SpellFocusBuilderProps> = ({ onBack }) => {
 	const availableProperties = useMemo(() => {
 		return getSelectableSpellFocusProperties();
 	}, []);
+
+	const filteredPresets = useMemo(
+		() =>
+			filterEquipmentPresets(PRESET_SPELL_FOCUSES, presetQuery, (preset) => [
+				preset.name,
+				preset.hands,
+				...preset.properties
+			]),
+		[presetQuery]
+	);
 
 	const validation = useMemo(() => {
 		if (!hands) return { isValid: false, errors: [], warnings: [] };
@@ -182,8 +195,13 @@ const SpellFocusBuilder: React.FC<SpellFocusBuilderProps> = ({ onBack }) => {
 
 					<div className="mb-6">
 						<h4 className="mb-3 text-sm font-semibold text-gray-400">Or Load a Preset</h4>
+						<PresetSearchInput
+							value={presetQuery}
+							onChange={setPresetQuery}
+							resultCount={filteredPresets.length}
+						/>
 						<OptionGrid>
-							{PRESET_SPELL_FOCUSES.map((preset) => (
+							{filteredPresets.map((preset) => (
 								<OptionCard
 									key={preset.id}
 									$selected={selectedPreset === preset.id}
@@ -208,6 +226,9 @@ const SpellFocusBuilder: React.FC<SpellFocusBuilderProps> = ({ onBack }) => {
 								</OptionCard>
 							))}
 						</OptionGrid>
+						{filteredPresets.length === 0 && (
+							<p className="py-4 text-center text-sm text-gray-500">No focus presets match.</p>
+						)}
 					</div>
 
 					<ActionButtons>

--- a/src/routes/custom-equipment/components/SpellFocusBuilder.tsx
+++ b/src/routes/custom-equipment/components/SpellFocusBuilder.tsx
@@ -44,14 +44,19 @@ import {
 
 interface SpellFocusBuilderProps {
 	onBack: () => void;
+	initialEquipment?: CustomSpellFocus;
 }
 
-const SpellFocusBuilder: React.FC<SpellFocusBuilderProps> = ({ onBack }) => {
+const SpellFocusBuilder: React.FC<SpellFocusBuilderProps> = ({ onBack, initialEquipment }) => {
 	const [step, setStep] = useState(1);
-	const [hands, setHands] = useState<SpellFocusHands | null>(null);
-	const [selectedProperties, setSelectedProperties] = useState<string[]>([]);
-	const [name, setName] = useState('');
-	const [selectedPreset, setSelectedPreset] = useState<string | null>(null);
+	const [hands, setHands] = useState<SpellFocusHands | null>(initialEquipment?.hands ?? null);
+	const [selectedProperties, setSelectedProperties] = useState<string[]>(
+		initialEquipment?.properties.filter((property) => property !== 'two-handed-focus') ?? []
+	);
+	const [name, setName] = useState(initialEquipment?.name ?? '');
+	const [selectedPreset, setSelectedPreset] = useState<string | null>(
+		initialEquipment?.presetOrigin ?? null
+	);
 	const [presetQuery, setPresetQuery] = useState('');
 
 	const maxPoints = useMemo(() => getMaxPointsForSpellFocus(hands === 'two-handed'), [hands]);
@@ -110,8 +115,9 @@ const SpellFocusBuilder: React.FC<SpellFocusBuilderProps> = ({ onBack }) => {
 		const props =
 			hands === 'two-handed' ? [...selectedProperties, 'two-handed-focus'] : selectedProperties;
 
+		const now = new Date().toISOString();
 		const focus: CustomSpellFocus = {
-			id: `custom-focus-${Date.now()}`,
+			id: initialEquipment?.id ?? `custom-focus-${Date.now()}`,
 			category: 'spellFocus',
 			name: name || 'Custom Spell Focus',
 			hands: hands!,
@@ -130,8 +136,8 @@ const SpellFocusBuilder: React.FC<SpellFocusBuilderProps> = ({ onBack }) => {
 			hasReactive: props.includes('reactive'),
 			isPreset: !!selectedPreset,
 			presetOrigin: selectedPreset || undefined,
-			createdAt: new Date().toISOString(),
-			updatedAt: new Date().toISOString()
+			createdAt: initialEquipment?.createdAt ?? now,
+			updatedAt: now
 		};
 
 		return withEquipmentEffects(focus);

--- a/src/routes/custom-equipment/components/WeaponBuilder.tsx
+++ b/src/routes/custom-equipment/components/WeaponBuilder.tsx
@@ -23,6 +23,8 @@ import type {
 	WeaponStyle
 } from '../../../lib/rulesdata/equipment/schemas/weaponSchema';
 import type { PhysicalDamageType } from '../../../lib/rulesdata/equipment/schemas/baseEquipment';
+import { filterEquipmentPresets } from '../presetSearch';
+import PresetSearchInput from './PresetSearchInput';
 import {
 	BuilderContainer,
 	SectionTitle,
@@ -58,6 +60,7 @@ const WeaponBuilder: React.FC<WeaponBuilderProps> = ({ onBack }) => {
 	const [selectedProperties, setSelectedProperties] = useState<string[]>([]);
 	const [name, setName] = useState('');
 	const [selectedPreset, setSelectedPreset] = useState<string | null>(null);
+	const [presetQuery, setPresetQuery] = useState('');
 
 	const maxPoints = weaponType === 'ranged' ? 1 : 2;
 
@@ -77,6 +80,19 @@ const WeaponBuilder: React.FC<WeaponBuilderProps> = ({ onBack }) => {
 		if (!weaponType) return [];
 		return getPropertiesForWeaponType(weaponType);
 	}, [weaponType]);
+
+	const filteredPresets = useMemo(
+		() =>
+			filterEquipmentPresets(PRESET_WEAPONS, presetQuery, (preset) => [
+				preset.name,
+				preset.weaponType,
+				preset.category,
+				preset.damageType,
+				...preset.styles,
+				...preset.properties
+			]),
+		[presetQuery]
+	);
 
 	const hasMultiFaceted = selectedProperties.includes('multi-faceted');
 
@@ -264,15 +280,14 @@ const WeaponBuilder: React.FC<WeaponBuilderProps> = ({ onBack }) => {
 
 					<div className="mb-6">
 						<h4 className="mb-3 text-sm font-semibold text-gray-400">Or Load a Preset</h4>
-						<div className="mb-2 flex gap-2">
-							<Badge variant="outline">Melee One-Handed</Badge>
-							<Badge variant="outline">Versatile</Badge>
-							<Badge variant="outline">Two-Handed</Badge>
-							<Badge variant="outline">Ranged</Badge>
-						</div>
+						<PresetSearchInput
+							value={presetQuery}
+							onChange={setPresetQuery}
+							resultCount={filteredPresets.length}
+						/>
 						<div className="max-h-96 overflow-y-auto">
 							<OptionGrid>
-								{PRESET_WEAPONS.slice(0, 12).map((preset) => (
+								{filteredPresets.map((preset) => (
 									<OptionCard
 										key={preset.id}
 										$selected={selectedPreset === preset.id}
@@ -303,16 +318,8 @@ const WeaponBuilder: React.FC<WeaponBuilderProps> = ({ onBack }) => {
 								))}
 							</OptionGrid>
 						</div>
-						{PRESET_WEAPONS.length > 12 && (
-							<Button
-								variant="ghost"
-								className="mt-2 w-full text-gray-400"
-								onClick={() => {
-									// Could add a modal or expand functionality
-								}}
-							>
-								View all {PRESET_WEAPONS.length} presets...
-							</Button>
+						{filteredPresets.length === 0 && (
+							<p className="py-4 text-center text-sm text-gray-500">No weapon presets match.</p>
 						)}
 					</div>
 

--- a/src/routes/custom-equipment/components/WeaponBuilder.tsx
+++ b/src/routes/custom-equipment/components/WeaponBuilder.tsx
@@ -49,17 +49,28 @@ import {
 
 interface WeaponBuilderProps {
 	onBack: () => void;
+	initialEquipment?: CustomWeapon;
 }
 
-const WeaponBuilder: React.FC<WeaponBuilderProps> = ({ onBack }) => {
+const WeaponBuilder: React.FC<WeaponBuilderProps> = ({ onBack, initialEquipment }) => {
 	const [step, setStep] = useState(1);
-	const [weaponType, setWeaponType] = useState<WeaponType | null>(null);
-	const [style, setStyle] = useState<WeaponStyle | null>(null);
-	const [secondaryStyle, setSecondaryStyle] = useState<WeaponStyle | null>(null);
-	const [damageType, setDamageType] = useState<PhysicalDamageType | null>(null);
-	const [selectedProperties, setSelectedProperties] = useState<string[]>([]);
-	const [name, setName] = useState('');
-	const [selectedPreset, setSelectedPreset] = useState<string | null>(null);
+	const [weaponType, setWeaponType] = useState<WeaponType | null>(
+		initialEquipment?.weaponType ?? null
+	);
+	const [style, setStyle] = useState<WeaponStyle | null>(initialEquipment?.style ?? null);
+	const [secondaryStyle, setSecondaryStyle] = useState<WeaponStyle | null>(
+		initialEquipment?.secondaryStyle ?? null
+	);
+	const [damageType, setDamageType] = useState<PhysicalDamageType | null>(
+		initialEquipment?.damageType ?? null
+	);
+	const [selectedProperties, setSelectedProperties] = useState<string[]>(
+		initialEquipment?.properties ?? []
+	);
+	const [name, setName] = useState(initialEquipment?.name ?? '');
+	const [selectedPreset, setSelectedPreset] = useState<string | null>(
+		initialEquipment?.presetOrigin ?? null
+	);
 	const [presetQuery, setPresetQuery] = useState('');
 
 	const maxPoints = weaponType === 'ranged' ? 1 : 2;
@@ -190,8 +201,9 @@ const WeaponBuilder: React.FC<WeaponBuilderProps> = ({ onBack }) => {
 	const buildWeapon = (): CustomWeapon => {
 		const styleData = WEAPON_STYLES.find((s) => s.id === style);
 
+		const now = new Date().toISOString();
 		const weapon: CustomWeapon = {
-			id: `custom-weapon-${Date.now()}`,
+			id: initialEquipment?.id ?? `custom-weapon-${Date.now()}`,
 			category: 'weapon',
 			name: name || 'Custom Weapon',
 			weaponType: weaponType!,
@@ -210,8 +222,8 @@ const WeaponBuilder: React.FC<WeaponBuilderProps> = ({ onBack }) => {
 			maxPoints,
 			isPreset: !!selectedPreset,
 			presetOrigin: selectedPreset || undefined,
-			createdAt: new Date().toISOString(),
-			updatedAt: new Date().toISOString()
+			createdAt: initialEquipment?.createdAt ?? now,
+			updatedAt: now
 		};
 
 		return withEquipmentEffects(weapon);

--- a/src/routes/custom-equipment/presetSearch.test.ts
+++ b/src/routes/custom-equipment/presetSearch.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { filterEquipmentPresets } from './presetSearch';
+
+const presets = [
+	{ name: 'Longsword', type: 'melee', properties: ['versatile'] },
+	{ name: 'Longbow', type: 'ranged', properties: ['two-handed', 'long-ranged'] }
+];
+
+const terms = (preset: (typeof presets)[number]) => [
+	preset.name,
+	preset.type,
+	...preset.properties
+];
+
+describe('filterEquipmentPresets', () => {
+	it('returns all presets for an empty query', () => {
+		expect(filterEquipmentPresets(presets, '  ', terms)).toEqual(presets);
+	});
+
+	it('matches every query token across name, type, and properties', () => {
+		expect(filterEquipmentPresets(presets, 'RANGED long', terms)).toEqual([presets[1]]);
+		expect(filterEquipmentPresets(presets, 'melee versatile', terms)).toEqual([presets[0]]);
+	});
+
+	it('returns an empty list when no preset matches', () => {
+		expect(filterEquipmentPresets(presets, 'shield', terms)).toEqual([]);
+	});
+});

--- a/src/routes/custom-equipment/presetSearch.ts
+++ b/src/routes/custom-equipment/presetSearch.ts
@@ -1,0 +1,14 @@
+export function filterEquipmentPresets<T>(
+	presets: readonly T[],
+	query: string,
+	getSearchTerms: (preset: T) => readonly string[]
+): T[] {
+	const tokens = query.trim().toLocaleLowerCase().split(/\s+/).filter(Boolean);
+
+	if (tokens.length === 0) return [...presets];
+
+	return presets.filter((preset) => {
+		const haystack = getSearchTerms(preset).join(' ').toLocaleLowerCase();
+		return tokens.every((token) => haystack.includes(token));
+	});
+}


### PR DESCRIPTION
## Summary

1. Search equipment options while building a character.
2. Prevent accidental duplicate saved equipment.
3. Edit saved equipment selections.

## Stack

1. Stacked on #138.
2. Merge after #138.
3. Next: rule-driven character effects.

## Validation

1. Production build passes on the complete stack.
2. Full unit comparison found no new product failure versus `main`.