### PR TITLE
feat(character-sheet): add alternative sheet workflow

### DIFF
--- a/docs/systems/CHARACTER_CREATION_FLOW.MD
+++ b/docs/systems/CHARACTER_CREATION_FLOW.MD
@@ -11,6 +11,7 @@
 #### Stage Contract
 
 - Ordering is data-driven and uses stable step IDs: 1) Class & Features → 2) Leveling (conditional when level > 1) → 3) Ancestry → 4) Attributes → 5) Background → 6) Spells (conditional) → 7) Maneuvers (conditional) → 8) Character Name. A leveled hybrid can therefore have eight visible steps.
+- Responsive presentation uses the shared 768px and 1200px thresholds from `src/styles/responsive.ts`. Below 1200px, the compact/tablet header reserves vertical space for the fixed auth controls so Previous/Next and load-screen Import actions do not overlap them. The compact class list uses one column below 768px, two columns from 768–1199px, and three columns from 1200px.
 - State lives in `characterContext.tsx`; each stage must read/write through the reducer actions (`SET_CLASS`, `SET_TRAITS`, `UPDATE_SKILLS`, etc.)
 - Step navigation is gated. Users can move backward, but cannot jump forward through the stepper until prior steps are complete.
 - Class changes clear downstream class/level-dependent selections. Level changes clear level-dependent selections such as talents, path points, multiclass choice, cross-path spell list, spells, and maneuvers.

--- a/docs/systems/CHARACTER_SHEET.MD
+++ b/docs/systems/CHARACTER_SHEET.MD
@@ -2,7 +2,7 @@
 
 > Purpose: End-to-end map of Character Sheet UI: architecture, components, data sources, and interactions.
 > Status: Active
-> Last Updated: 2026-07-24
+> Last Updated: 2026-07-25
 
 ## Recent UX additions
 
@@ -168,12 +168,16 @@ Campaign-only queries, mutations, event producers, and feed notifications mount 
   dedicated resolved Size badge for `SET_VALUE:size`.
 - Keep `calculatorModules/effectCollection.ts` as the source-attributed aggregation layer. The new service should be presentation-oriented and should not duplicate stat math from `calculateCharacterWithBreakdowns()`.
 
-#### Attack Sheet TODOs
+#### Attack Sheet Notes
 
 - `attackPresentation.ts` applies active attack-scoped effects without rewriting saved
   attack rows. Barbarian Rage `MODIFY_STAT:martial_melee_damage +1 while_raging`
   applies to catalog melee weapons and persisted Unarmed Strike rows; ranged and unknown
   custom rows remain unchanged.
+- A selected Beastborn Natural Weapon trait derives a read-only, non-inventory
+  `Natural Weapon (Unarmed Strike)` row. Until damage-type choice state is modeled,
+  the row presents base/heavy/brutal damage as `1/2/3 B/P/S`. The derived row is not
+  written into `characterState.attacks`.
 
 v0.10.5 level 5 Expert Features intentionally keep the old `<class>_level_5_placeholder` IDs. Saved characters that already reference those IDs render the updated Expert Feature names, benefits, and modeled effects without needing a destructive ID rewrite.
 

--- a/docs/systems/CHARACTER_SHEET.MD
+++ b/docs/systems/CHARACTER_SHEET.MD
@@ -1,24 +1,32 @@
-# DC20Clean ? Character Sheet
+# DC20Clean – Character Sheet
 
 > Purpose: End-to-end map of Character Sheet UI: architecture, components, data sources, and interactions.
+> Owns: Character-sheet state and presentation, in-play resource controls, sheet actions, auto-save coordination, responsive layouts, and read-only rendering.
+> Does not own: Character-creation rules, derived-stat formulas, persistence implementations, campaign authorization, or PDF field mapping.
+> Authoritative source: `src/routes/character-sheet/`, especially `hooks/CharacterSheetProvider.tsx`, the sheet reducer, and section components.
+> Related systems: [Calculation](./CALCULATION_SYSTEM.MD), [Database](./DATABASE_SYSTEM.MD), [Campaigns](./CAMPAIGN_SYSTEM.MD), [PDF Export](./PDF_EXPORT_SYSTEM.MD), [Conditions](./CONDITIONS_SYSTEM.MD).
 > Status: Active
 > Last Updated: 2026-07-25
 
 ## Recent UX additions
 
-- **Alternative sheet route**: `/character2/:id` renders the incremental alternative sheet under the same `CharacterSheetProvider`; `/character2/` resolves the most recently modified saved character. Its first slice contains only the identity/action header and horizontal HP/Mana/Stamina/Rest/Grit strip. It reuses `StatCard`, the existing reducer mutations, Long Rest behavior, stored-value PDF export, JSON export, and Rulebook article links. Mana and Stamina are each omitted when their maximum is zero. This route adds no schema or persistence path.
-- **Hero strip restructured to 3 columns**: `HeroSection` uses a responsive three-column layout:
+- **Responsive contract**: The live menu and primary sheet use two shared viewport thresholds from `src/styles/responsive.ts`: tablet begins at 768px and desktop begins at 1200px. Compact layouts are the base below 768px; tablet layouts occupy 768–1199px; desktop layouts begin at 1200px. Component internals use fluid grids, wrapping, intrinsic minimums, and container queries instead of additional viewport breakpoints. The primary sheet keeps a stable 280px attribute column above the compact threshold. Spell and Maneuver rows switch between labelled cards and full table rows according to the tab container's available width, so crossing 1200px does not force a cramped table.
+- **Alternative sheet route**: `/character2/:id` renders the incremental alternative sheet under the same `CharacterSheetProvider`; `/character2/` resolves the most recently modified saved character. Every saved-character card on `/load-character` offers separate `View Sheet` and `Alternative Sheet` actions, with the current sheet remaining the default. The alternative sheet currently contains the identity/action header, horizontal HP/Mana/Stamina/Rest/Grit strip, an attribute-mastery section, a full-width combat strip, and a tabbed action/detail panel below them. The panel reuses the existing Attacks, Spells, Inventory, Maneuvers, Features, Conditions, and Notes content; its tab bar remains horizontally scrollable on narrow screens and switches content without entry animation. The active tab supplies the section label, so the alternative sheet suppresses each reused panel's duplicate top-level title while retaining controls, category headings, and active counts. The mastery section groups every Skill under its governing Attribute, assigns each selected Trade to its highest valid Attribute total, keeps Awareness under Prime, and sends Attribute Saves, Skills, and Trades to the shared automatic Dice Roller with active-condition modifiers. The combat strip gives Attack primary-action hierarchy, groups Save DC/Initiative/Move/Jump as tactical metrics, and presents PD/AD as paired Hit, Heavy Hit, and Brutal Hit threshold ladders beside a shared PDR/EDR/MDR status column. Read-only PDR/EDR/MDR indicators are sourced from categorical resistance grants. Attack and Initiative send to the same Dice Roller. It reuses `StatCard`, the existing reducer mutations, Long Rest behavior, stored-value PDF export, JSON export, and Rulebook article links. Mana and Stamina are each omitted when their maximum is zero. Alternative-sheet `StatCard` instances skip mount fade and initial bar-fill transitions while retaining value-change and control feedback. This route adds no schema or persistence path.
+- **Alternative sheet color roles**: Structural surfaces and passive values stay neutral; crystal blue identifies roll actions and interaction states; each Attribute color is limited to its title, top border, and filled mastery dots; both defenses use the purple defense family; resource colors retain their established meanings; green is reserved for active positive states such as damage reduction.
+- **Alternative tab interaction**: Subtle dividers separate the uppercase tabs; the active tab uses a crystal-tinted surface, inset outline, and thicker top accent. Editable rows in Attacks, Spells, Inventory, Maneuvers, and Notes share one explicit lifecycle: Add creates a row in edit mode, a trailing pencil enters edit mode, check finishes, and delete is available only while editing. Features and Conditions retain their existing view/control behavior. These changes are scoped to the alternative sheet where shared components also appear on the current sheet.
+- **Hero strip restructured to fluid columns**: `HeroSection` uses a container-driven layout:
   - **Col 1**: Health (HP + Temp HP + Health Status + Exhaustion) — unchanged.
   - **Col 2**: Resources (Mana and Stamina) above Recovery (Rest and Grit).
   - **Col 3**: Combat Stats with compact movement, currency, senses, resistances, vulnerabilities, and combat training.
-  - Responsive: 2 columns at <=1200px, 1 column at <=768px.
-- **Resource controls**: Editable HP, Mana, Stamina, Rest, Grit, and Temp HP values place decrement/increment controls directly around the value (`− current / max +`); current and maximum values use equal-sized, equal-width tabular numeral slots around a centered separator, so different digit counts and negative HP do not unbalance the control. The alternative sheet stretches every resource card to the tallest card in its row. The redundant “Main” label is removed. In the Health card, Temp HP is an unframed standalone control below the HP progress bar; changing it never changes current or maximum HP. The bar reserves 25% of its width for negative HP and 75% for normal HP, with a subtle zero marker between them; negative HP fills and animates leftward from zero in alert red. Current HP and Temp HP render as separate resource-coloured and yellow segments. Damage consumes Temp HP first, then HP. HP can decrease to the calculated negative Death Threshold.
+  - Cards keep an 18rem intrinsic minimum and move between three, two, and one columns according to the width available inside the sheet, without adding viewport breakpoints.
+  - Mana/Stamina and Rest/Grit remain two equal inner columns, and the three defense values remain one equal row, at every hero width that renders the desktop/tablet sheet.
+- **Resource controls**: Editable HP, Mana, Stamina, Rest, Grit, and Temp HP values place decrement/increment controls directly around the value (`− current / max +`); current and maximum values use equal-sized, equal-width tabular numeral slots around a centered separator, so different digit counts and negative HP do not unbalance the control. The alternative sheet stretches every resource card to the tallest card in its row and reserves an equal-height status row in every card, keeping all progress bars aligned. The calculated Health Status chip sits close beneath the HP label with separation from the value. The redundant “Main” label is removed. In the Health card, Temp HP is an unframed standalone control below the HP progress bar; changing it never changes current or maximum HP. The bar reserves 25% of its width for negative HP and 75% for normal HP, with a subtle zero marker between them; negative HP fills and animates leftward from zero in alert red. Current HP and Temp HP render as separate resource-coloured and yellow segments. Damage consumes Temp HP first, then HP. HP can decrease to the calculated negative Death Threshold.
 - **HP formula tooltip**: HP hover keeps the shared tabular calculation tooltip, but dynamically splits calculator base HP into class progression (`Level · Class`) and Might rows, followed by every source-attributed HP modifier such as ancestry traits, class features, talents, and equipped items. A second table shows the displayed negative Death Threshold as Prime Attribute + Combat Mastery + source-attributed modifiers.
 - **Hero card hierarchy**: The hero strip omits redundant Health, Resources, Recovery, and Combat Stats headings. Conditional reset actions remain available without reserving header space when no override exists.
 - **Compact resource labels**: Hero resource cards use Hit Points, Mana, Stamina, Rest, and Grit without the redundant “Points” suffix.
 - **Defense cards**: Combat Stats uses the canonical labels PD, Damage Reduction, and AD. Both PD and AD show Heavy and Brutal thresholds on separate lines using defense +5/+10.
 - **Attribute headers**: Might, Agility, Charisma, and INT use a compact `Attribute ±score (±save save)` reading order; duplicate abbreviation boxes are removed while score tooltips and clickable save rolls remain intact.
-- **Prime hierarchy**: Combat Mastery appears first. Prime follows the compact attribute-header pattern and owns the Awareness skill row inside its bordered section.
+- **Prime hierarchy**: Prime occupies the first column beside the four Attributes, uses their exact header structure and spacing, and owns Awareness. Compact Combat Mastery sits directly beneath Prime. Both cards use purple top-border accents, with Combat Mastery using a 30%-lighter treatment. Awareness and every Attribute skill list share the same top baseline.
 - **CompactUtility component** (`components/new/CompactUtility.tsx`): compact replacement for the old Utility tab:
   1. Move | Jump as two mini stat cards in one row.
   2. GP | SP | CP inline editable pills.
@@ -176,10 +184,19 @@ Campaign-only queries, mutations, event producers, and feed notifications mount 
   attack rows. Barbarian Rage `MODIFY_STAT:martial_melee_damage +1 while_raging`
   applies to catalog melee weapons and persisted Unarmed Strike rows; ranged and unknown
   custom rows remain unchanged.
+- `ancestryAttackTraits.ts` interprets selected ancestry trait IDs for attack-row
+  presentation without rewriting saved attacks. Orc Brutal Strikes adds +1 only to the
+  displayed Brutal damage of supported melee weapons and Unarmed Strikes. Finishing Blow
+  and Beastborn Charge remain condition-dependent notes and never change the displayed
+  damage automatically.
 - A selected Beastborn Natural Weapon trait derives a read-only, non-inventory
   `Natural Weapon (Unarmed Strike)` row. Until damage-type choice state is modeled,
   the row presents base/heavy/brutal damage as `1/2/3 B/P/S`. The derived row is not
-  written into `characterState.attacks`.
+  written into `characterState.attacks`. Selected Natural Weapon extensions are rendered
+  on that row as properties or rules notes: Reach, ranged range, Concealable, Style
+  enhancement eligibility, Rend, and Venomous. Long-Limbed appears on every supported
+  melee attack. Natural Weapon Style does not infer a style because the character model
+  does not currently persist that choice.
 
 v0.10.5 level 5 Expert Features intentionally keep the old `<class>_level_5_placeholder` IDs. Saved characters that already reference those IDs render the updated Expert Feature names, benefits, and modeled effects without needing a destructive ID rewrite.
 

--- a/docs/systems/CHARACTER_SHEET.MD
+++ b/docs/systems/CHARACTER_SHEET.MD
@@ -2,16 +2,17 @@
 
 > Purpose: End-to-end map of Character Sheet UI: architecture, components, data sources, and interactions.
 > Status: Active
-> Last Updated: 2026-07-20
+> Last Updated: 2026-07-24
 
 ## Recent UX additions
 
+- **Alternative sheet route**: `/character2/:id` renders the incremental alternative sheet under the same `CharacterSheetProvider`; `/character2/` resolves the most recently modified saved character. Its first slice contains only the identity/action header and horizontal HP/Mana/Stamina/Rest/Grit strip. It reuses `StatCard`, the existing reducer mutations, Long Rest behavior, stored-value PDF export, JSON export, and Rulebook article links. Mana and Stamina are each omitted when their maximum is zero. This route adds no schema or persistence path.
 - **Hero strip restructured to 3 columns**: `HeroSection` uses a responsive three-column layout:
   - **Col 1**: Health (HP + Temp HP + Health Status + Exhaustion) — unchanged.
   - **Col 2**: Resources (Mana and Stamina) above Recovery (Rest and Grit).
   - **Col 3**: Combat Stats with compact movement, currency, senses, resistances, vulnerabilities, and combat training.
   - Responsive: 2 columns at <=1200px, 1 column at <=768px.
-- **Resource controls**: Editable HP, Mana, Stamina, Rest, Grit, and Temp HP values place decrement/increment controls directly around the value (`− current / max +`); current values use fixed-width tabular numeral slots so entering negative HP does not shift adjacent controls. The redundant “Main” label is removed. In the Health card, Temp HP is a standalone value below HP and above the bar; changing it never changes current or maximum HP. The bar reserves 25% of its width for negative HP and 75% for normal HP, with a subtle zero marker between them; negative HP fills and animates leftward from zero in alert red. Current HP and Temp HP render as separate resource-coloured and yellow segments. Damage consumes Temp HP first, then HP. HP can decrease to the calculated negative Death Threshold.
+- **Resource controls**: Editable HP, Mana, Stamina, Rest, Grit, and Temp HP values place decrement/increment controls directly around the value (`− current / max +`); current and maximum values use equal-sized, equal-width tabular numeral slots around a centered separator, so different digit counts and negative HP do not unbalance the control. The alternative sheet stretches every resource card to the tallest card in its row. The redundant “Main” label is removed. In the Health card, Temp HP is an unframed standalone control below the HP progress bar; changing it never changes current or maximum HP. The bar reserves 25% of its width for negative HP and 75% for normal HP, with a subtle zero marker between them; negative HP fills and animates leftward from zero in alert red. Current HP and Temp HP render as separate resource-coloured and yellow segments. Damage consumes Temp HP first, then HP. HP can decrease to the calculated negative Death Threshold.
 - **HP formula tooltip**: HP hover keeps the shared tabular calculation tooltip, but dynamically splits calculator base HP into class progression (`Level · Class`) and Might rows, followed by every source-attributed HP modifier such as ancestry traits, class features, talents, and equipped items. A second table shows the displayed negative Death Threshold as Prime Attribute + Combat Mastery + source-attributed modifiers.
 - **Hero card hierarchy**: The hero strip omits redundant Health, Resources, Recovery, and Combat Stats headings. Conditional reset actions remain available without reserving header space when no override exists.
 - **Compact resource labels**: Hero resource cards use Hit Points, Mana, Stamina, Rest, and Grit without the redundant “Points” suffix.
@@ -85,6 +86,7 @@ For `upgrade-required` and `view-only` characters, the sheet suppresses fresh ca
 | File                                | Role                                                              |
 | ----------------------------------- | ----------------------------------------------------------------- |
 | `CharacterSheetRouter.tsx`          | Entry point; provides context, routes to layout                   |
+| `alternative/`                      | Incrementally built `/character2` layout using the same provider  |
 | `CharacterSheetRedesign.tsx`        | Primary responsive layout (mobile/tablet/desktop via CSS)         |
 | `CharacterSheetDesktop.tsx`         | Desktop-only layout variant                                       |
 | `CharacterSheetMobile.tsx`          | Mobile layout with tab navigation                                 |

--- a/docs/systems/CHARACTER_SHEET.MD
+++ b/docs/systems/CHARACTER_SHEET.MD
@@ -36,6 +36,7 @@
 - **Maneuver row interaction**: Maneuver rows mirror spells: clicking the row toggles details, Use remains directly available, changing/removing a slot requires its trailing pencil action, and expansion state persists across sheet-tab changes until reload.
 - **Spell row readability**: Spell names use the sheet's primary foreground color and semibold weight so they remain legible against the dark row background.
 - **Desktop header hierarchy**: Character identity and sheet actions are stacked vertically so long names and the toolbar do not compete for one horizontal row.
+- **Tablet header and floating tools**: The tablet action toolbar stays on one horizontally scrollable row to limit sticky-header height. The collapsed Dice Roller is a narrow edge tab; expanding it restores the full panel inside the viewport.
 - **Ancestry identity**: The header shows the second ancestry only when it exists; legacy `Unknown` placeholders are suppressed with the separator.
 - **Class identity link**: When the saved class ID matches a generated Rulebook article, the `Level + Class` header metadata links directly to `/rulebook/classes/{classId}`; unmatched legacy IDs remain plain text instead of linking to a missing article.
 - **Feature progression display**: The Features tab renders all eligible core class features through the character's level, plus separate Subclass Features, Path Progression, and Talents sections. Talents include both ordinary `selectedTalents` and multiclass Talent selections; path entries resolve from `pathPointAllocations`. Missing selections are not inferred.
@@ -93,7 +94,8 @@ For `upgrade-required` and `view-only` characters, the sheet suppresses fresh ca
 | `CharacterSheetClean.tsx`           | Legacy clean layout (desktop/mobile conditional)                  |
 | `hooks/CharacterSheetProvider.tsx`  | Context provider with state management, auto-save, selector hooks |
 | `hooks/useCharacterSheetReducer.ts` | Reducer for local character sheet state                           |
-| `hooks/useBreakpoint.ts`            | Responsive breakpoint detection                                   |
+| `hooks/useBreakpoint.ts`            | Three layout modes derived from two shared viewport thresholds    |
+| `src/styles/responsive.ts`          | Shared 768px and 1200px breakpoint values and media helpers       |
 
 ---
 

--- a/docs/systems/PROJECT_TECHNICAL_OVERVIEW.MD
+++ b/docs/systems/PROJECT_TECHNICAL_OVERVIEW.MD
@@ -19,11 +19,12 @@
 
 ## UI Notes
 
+- `src/styles/responsive.ts` is the viewport-breakpoint authority. It defines only 768px and 1200px, producing compact, tablet, and desktop modes. Prefer intrinsic CSS (`minmax`, `auto-fit`, wrapping, `clamp`, and container queries) for component-level adaptation; do not add viewport thresholds for isolated components.
 - Replace ad hoc hand-drawn SVG icons across the app with a consistent icon set, preferably `lucide-react` where an appropriate icon exists. Start with menu/reference-tool icons, then sheet action icons, builders, and popups.
 - Create a dedicated `docs/systems/UI_SYSTEM.MD` if UI conventions continue to grow beyond this overview. It should cover layout grids, icon usage, responsive rules, shared primitives, and visual QA expectations.
 - Userback feedback is a UI widget, not a storage system. The install snippet lives in `index.html`; `src/components/UserbackFeedback.tsx` adds compact route/character/target metadata. Do not send full saved characters, notes, inventory, or localStorage dumps.
 - The fixed top-right toolbar keeps authentication as the rightmost primary action. The compact language trigger shows only the current flag; full language names remain in the dropdown and accessible label.
-- Signed-in DM and campaign menu actions share one four-card desktop row with separate “DM Tools” and “Campaigns” headings. The two groups stack below 900px, and their cards stack below 600px.
+- Signed-in DM and campaign menu actions share one four-card desktop row with separate “DM Tools” and “Campaigns” headings. The groups stack below 1200px; their cards stack below 768px.
 - The Rule Book menu card spans two columns and is centered beneath the four standard reference-tool cards on desktop, using the same 1.5rem vertical rhythm as the menu sections.
 
 ## Local Setup

--- a/docs/systems/TESTING_SYSTEM.MD
+++ b/docs/systems/TESTING_SYSTEM.MD
@@ -69,6 +69,13 @@ npm run e2e:agentic:summarize
 
 Known environment note: browser/E2E failures can be environment-driven when Playwright browsers are missing. For rules migration slices, focused server tests plus source-audit validators are the stronger first signal.
 
+Responsive UI changes must verify the shared boundary pairs rather than arbitrary device names:
+
+1. Compact/tablet: 767px and 768px.
+2. Tablet/desktop: 1199px and 1200px.
+3. Include at least one narrow phone width, currently 390px, and assert `document.documentElement.scrollWidth <= window.innerWidth`.
+4. Prefer component-width assertions and visible controls over screenshot-only checks.
+
 ---
 
 ## 3. Coverage Contract

--- a/docs/systems/TRAITS_SYSTEM.MD
+++ b/docs/systems/TRAITS_SYSTEM.MD
@@ -1,6 +1,10 @@
 # DC20Clean – Traits System
 
 > Purpose: Single reference for Traits: data shape, effect typing, validation, runtime processing, and UI usage.
+> Owns: Trait definitions, trait IDs, prerequisites, trait choices, trait validation, trait effect declarations, and trait-facing UI behavior.
+> Does not own: Ancestry composition, generic effect semantics, derived-stat formulas, or overall ancestry-stage orchestration.
+> Authoritative source: `docs/assets/dc20-0.10.5/DC20 0.10.5 clean.md`, `docs/migration/ancestries-v0105-report.json`, and `src/lib/rulesdata/ancestries/traits.ts`.
+> Related systems: [Ancestries](./ANCESTRY_SYSTEM.MD), [Effects](./EFFECT_SYSTEM.MD), [Calculation](./CALCULATION_SYSTEM.MD), [Character Creation](./CHARACTER_CREATION_FLOW.MD).
 > Status: Active
 > Last Updated: 2026-07-25
 
@@ -60,6 +64,11 @@ Notes:
 - Use `schemas/character.schema.ts` as the source of truth for `Effect.type` strings. See also `docs/systems/EFFECT_SYSTEM.MD`.
 - `traits.ts` currently imports `Trait` from `schemas/character.schema.ts` to ensure alignment.
 - For resource maximums, use `hpMax`, `spMax`, and `mpMax` as `target` values. Avoid `mp` (not processed for maximums).
+- Attack-facing ancestry abilities that remain `GRANT_ABILITY` are interpreted by
+  `src/routes/character-sheet/ancestryAttackTraits.ts`. It scopes trait notes and
+  properties to supported attacks and applies Orc Brutal Strikes only to displayed
+  Brutal damage. Conditional traits such as Finishing Blow and Charge remain notes;
+  the sheet does not assume their trigger occurred.
 
 ### Acceptance Criteria (Traits)
 

--- a/docs/systems/TRAITS_SYSTEM.MD
+++ b/docs/systems/TRAITS_SYSTEM.MD
@@ -2,7 +2,7 @@
 
 > Purpose: Single reference for Traits: data shape, effect typing, validation, runtime processing, and UI usage.
 > Status: Active
-> Last Updated: 2026-07-13
+> Last Updated: 2026-07-25
 
 ---
 
@@ -344,6 +344,9 @@ the structured contract.
 - `beastborn_additional_limb` now reflects the v0.10.5 1 Space limb, object handling, push/pull/grapple, and no Weapon/Shield/Spell Focus/Somatic use limitations.
 - `beastborn_capable_limb` costs 2 points and upgrades an Additional Limb to use Weapons, Shields, Spell Focuses, and Somatic Components. Its prerequisite remains `beastborn_additional_limb`.
 - `beastborn_natural_weapon_style` is the current v0.10.5 Natural Weapon trait. The stale `beastborn_natural_weapon_passive` record was removed.
+- `beastborn_natural_weapon` derives a read-only Unarmed Strike on the character sheet.
+  Its unresolved Bludgeoning/Piercing/Slashing choice is presented as `B/P/S`; this
+  display behavior does not add an attack to persisted character state.
 
 ---
 

--- a/e2e/hunter-beastborn.e2e.spec.ts
+++ b/e2e/hunter-beastborn.e2e.spec.ts
@@ -25,12 +25,12 @@ test.describe('Hunter (Beastborn, Urban + Grassland) E2E', () => {
 		await page.getByTestId('ancestry-card-beastborn').click();
 
 		// Select traits: Glide Speed (2), Limited Flight (2), Full Flight (2), Winged Arms (-1), Small-Sized (-1), Natural Weapon (1)
-		await page.getByLabel(/Glide Speed/i).check();
-		await page.getByLabel(/Limited Flight/i).check();
-		await page.getByLabel(/Winged Arms/i).check();
-		await page.getByLabel(/Full Flight/i).check();
-		await page.getByLabel(/Small-Sized/i).check();
-		await page.getByRole('checkbox', { name: /^Natural Weapon \(1 pts\)/i }).check();
+		await page.getByTestId('trait-card-beastborn_glide_speed').click();
+		await page.getByTestId('trait-card-beastborn_limited_flight').click();
+		await page.getByTestId('trait-card-beastborn_winged_arms').click();
+		await page.getByTestId('trait-card-beastborn_full_flight').click();
+		await page.getByTestId('trait-card-beastborn_small_sized').click();
+		await page.getByTestId('trait-card-beastborn_natural_weapon').click();
 
 		await page.getByRole('button', { name: 'Next →' }).click();
 
@@ -51,29 +51,21 @@ test.describe('Hunter (Beastborn, Urban + Grassland) E2E', () => {
 		await page.getByTestId('skills-tab').click();
 
 		async function setSkillLevel(skillId: string, level: number) {
-			const row = page.getByTestId(`skill-item-${skillId}`);
-			await row.getByRole('button', { name: `${level}`, exact: true }).click();
+			await page.getByTestId(`skill-${skillId}-mastery-${level}`).click();
 		}
 
 		// We should have 8 skill points: base 5 + INT(1) + Urban(+2) = 8
 		await expect(page.getByTestId('skill-points-remaining')).toContainText('8 /');
 
-		// Awareness at Adept (2)
+		// Awareness at Adept costs 3 points: 2 mastery + 1 cap elevation.
 		await setSkillLevel('awareness', 2);
 
-		// Six more skills at Novice (1), covering each attribute association
+		// Five more skills at Novice (1), covering each attribute association.
 		// might: athletics, intimidation
-		// agility: acrobatics, trickery
-		// charisma: insight or influence (pick insight to not clash with Urban later); also animal
-		// intelligence: investigation (we already have INT to 1; this uses points only)
-		const noviceSkills = [
-			'athletics',
-			'intimidation',
-			'acrobatics',
-			'trickery',
-			'animal',
-			'investigation'
-		];
+		// agility: acrobatics
+		// charisma: animal
+		// intelligence: investigation
+		const noviceSkills = ['athletics', 'intimidation', 'acrobatics', 'animal', 'investigation'];
 		for (const s of noviceSkills) {
 			await setSkillLevel(s, 1);
 		}
@@ -85,11 +77,10 @@ test.describe('Hunter (Beastborn, Urban + Grassland) E2E', () => {
 		// Trades
 		await page.getByTestId('trades-tab').click();
 		async function setTradeLevel(tradeName: string, level: number) {
-			const row = page.getByTestId(`trade-item-${tradeName.toLowerCase()}`);
-			await row.getByRole('button', { name: `${level}`, exact: true }).click();
+			await page.getByTestId(`trade-${tradeName.toLowerCase()}-mastery-${level}`).click();
 		}
 		// Use 3 points across three trades at level 1 (avoid Adept due to Level 1 Adept cap already used by Awareness)
-		const tradesToLevel1 = ['Alchemy', 'Blacksmithing', 'Calligraphy'];
+		const tradesToLevel1 = ['Alchemy', 'Blacksmithing', 'Illustration'];
 		for (const t of tradesToLevel1) {
 			await setTradeLevel(t, 1);
 		}
@@ -118,17 +109,19 @@ test.describe('Hunter (Beastborn, Urban + Grassland) E2E', () => {
 		});
 
 		// Select maneuvers by clicking LEARN buttons
-		const learnButtons = page.locator('button:has-text("LEARN")');
+		const learnButtons = page.locator(
+			'button[data-action-id^="maneuver-"][data-action-id$="-learn"]:not(:disabled)'
+		);
 		// Hunter needs maneuvers based on their totalManeuversKnown
 		// Add the first available maneuvers until we have enough
-		const maneuversNeeded = 4; // Based on Hunter's progression
+		const maneuversNeeded = 2; // Level 1 Hunter progression
 		for (let i = 0; i < maneuversNeeded; i++) {
 			await learnButtons.first().click();
 			await page.waitForTimeout(200);
 		}
 
 		// Verify all maneuvers are selected (check for "All choices complete")
-		await expect(page.getByText(/All choices complete|0 remaining/i)).toBeVisible({
+		await expect(page.getByText(/All choices complete/i)).toBeVisible({
 			timeout: 5000
 		});
 		await page.getByRole('button', { name: 'Next →' }).click(); // proceed to Names
@@ -136,16 +129,7 @@ test.describe('Hunter (Beastborn, Urban + Grassland) E2E', () => {
 		// Step 6: Names
 		await page.getByLabel(/Character Name/i).fill('hunter beastborn urban grassland');
 		await page.getByLabel(/Player Name/i).fill('playwright');
-		await page.getByText(/Complete|Finish/i).click();
-
-		// After completion, app navigates to Load Character
-		await page.waitForURL('**/load-character');
-
-		// Open the saved character's sheet
-		const charCard = page.locator('div', { hasText: 'hunter beastborn urban grassland' }).first();
-		await charCard.getByRole('button', { name: 'View Sheet' }).click();
-
-		// Wait for character sheet route
+		await page.getByTestId('creation-next').click();
 		await page.waitForURL('**/character/**');
 
 		// Verify saved data in storage as a backstop
@@ -154,7 +138,7 @@ test.describe('Hunter (Beastborn, Urban + Grassland) E2E', () => {
 			return list.find((c: any) => c.finalName === 'hunter beastborn urban grassland');
 		});
 		expect(saved).toBeTruthy();
-		expect(saved.finalHPMax).toBe(8);
+		expect(saved.finalHPMax).toBe(7);
 		expect(saved.finalMoveSpeed).toBe(6);
 
 		// On sheet: check Movement and Features text - tolerate mobile label variations
@@ -186,10 +170,6 @@ test.describe('Hunter (Beastborn, Urban + Grassland) E2E', () => {
 			console.log(
 				'Move speed not found on sheet - continuing because saved object asserts move speed'
 			);
-		await expect(page.getByText(/FEATURES/i).first()).toBeVisible();
-		await expect(page.getByText(/Natural Weapon/i).first()).toBeVisible();
-		await expect(page.getByText(/Full Flight/i)).toBeVisible();
-		await expect(page.getByText(/Small-Sized/i)).toBeVisible();
 
 		const naturalWeaponAttack = page.getByTestId('natural-weapon-attack-row');
 		await expect(naturalWeaponAttack).toBeVisible();
@@ -197,5 +177,10 @@ test.describe('Hunter (Beastborn, Urban + Grassland) E2E', () => {
 		await expect(naturalWeaponAttack).toContainText('1 B/P/S');
 		await expect(naturalWeaponAttack).toContainText('2 B/P/S');
 		await expect(naturalWeaponAttack).toContainText('3 B/P/S');
+
+		await page.getByRole('button', { name: /Features/i }).click();
+		await expect(page.getByText('Natural Weapon', { exact: true }).first()).toBeVisible();
+		await expect(page.getByText('Full Flight', { exact: true }).first()).toBeVisible();
+		await expect(page.getByText('Small-Sized', { exact: true }).first()).toBeVisible();
 	});
 });

--- a/e2e/hunter-beastborn.e2e.spec.ts
+++ b/e2e/hunter-beastborn.e2e.spec.ts
@@ -187,14 +187,15 @@ test.describe('Hunter (Beastborn, Urban + Grassland) E2E', () => {
 				'Move speed not found on sheet - continuing because saved object asserts move speed'
 			);
 		await expect(page.getByText(/FEATURES/i).first()).toBeVisible();
-		await expect(page.getByText(/Natural Weapon/i)).toBeVisible();
+		await expect(page.getByText(/Natural Weapon/i).first()).toBeVisible();
 		await expect(page.getByText(/Full Flight/i)).toBeVisible();
 		await expect(page.getByText(/Small-Sized/i)).toBeVisible();
 
-		// TODO (future): Verify a Natural Weapon attack entry exists in Attacks section
-		// Example stub (enable after Attacks renders natural weapons):
-		// const attacksSection = page.getByText(/Attacks/i);
-		// await attacksSection.click();
-		// await expect(page.getByText(/Natural Weapon/i)).toBeVisible();
+		const naturalWeaponAttack = page.getByTestId('natural-weapon-attack-row');
+		await expect(naturalWeaponAttack).toBeVisible();
+		await expect(naturalWeaponAttack).toContainText('Natural Weapon (Unarmed Strike)');
+		await expect(naturalWeaponAttack).toContainText('1 B/P/S');
+		await expect(naturalWeaponAttack).toContainText('2 B/P/S');
+		await expect(naturalWeaponAttack).toContainText('3 B/P/S');
 	});
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import CharacterCreation from './routes/character-creation/CharacterCreation.tsx
 import { CharacterProvider } from './lib/stores/characterContext';
 import LoadCharacter from './routes/character-creation/LoadCharacter.tsx';
 import CharacterSheetRouter from './routes/character-sheet/CharacterSheetRouter';
+import AlternativeCharacterSheetRouter from './routes/character-sheet/alternative/AlternativeCharacterSheetRouter';
 import LevelUp from './routes/character-creation/LevelUp';
 import Menu from './components/Menu.tsx';
 import Spellbook from './routes/spellbook/Spellbook.tsx';
@@ -159,6 +160,8 @@ function App() {
 						/>
 						<Route path="/custom-equipment" element={<CustomEquipment />} />
 						<Route path="/character/:id" element={<CharacterSheetRouteWrapper />} />
+						<Route path="/character2" element={<AlternativeCharacterSheetRouteWrapper />} />
+						<Route path="/character2/:id" element={<AlternativeCharacterSheetRouteWrapper />} />
 						<Route
 							path="/character/:id/edit"
 							element={
@@ -189,6 +192,11 @@ function App() {
 function CharacterSheetRouteWrapper() {
 	const { id } = useParams();
 	return id ? <CharacterSheetRouter characterId={id} /> : null;
+}
+
+function AlternativeCharacterSheetRouteWrapper() {
+	const { id } = useParams();
+	return <AlternativeCharacterSheetRouter characterId={id} />;
 }
 
 function CampaignCharacterViewWrapper() {

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -200,7 +200,7 @@ import {
 } from './styled';
 
 import { useNavigate } from 'react-router-dom';
-import { BookOpenText } from 'lucide-react';
+import { BookOpenText, KeyRound, Map } from 'lucide-react';
 import { useIsAuthenticated } from './auth';
 import { useAppAuth } from './auth/AuthModeContext';
 import { useTranslation } from 'react-i18next';
@@ -303,13 +303,17 @@ function Menu() {
 								<StyledSectionTitle>{t('menu.campaignsSection')}</StyledSectionTitle>
 								<StyledDMGroupCards>
 									<StyledMenuCard $variant="dm" onClick={() => navigate('/campaigns')}>
-										<StyledIcon $variant="dm">Map</StyledIcon>
+										<StyledIcon $variant="dm">
+											<Map aria-hidden="true" />
+										</StyledIcon>
 										<StyledTextContent>
 											<StyledCardTitle $variant="dm">{t('menu.myCampaigns')}</StyledCardTitle>
 										</StyledTextContent>
 									</StyledMenuCard>
 									<StyledMenuCard $variant="dm" onClick={() => navigate('/campaigns/join')}>
-										<StyledIcon $variant="dm">Key</StyledIcon>
+										<StyledIcon $variant="dm">
+											<KeyRound aria-hidden="true" />
+										</StyledIcon>
 										<StyledTextContent>
 											<StyledCardTitle $variant="dm">{t('menu.joinCampaign')}</StyledCardTitle>
 										</StyledTextContent>

--- a/src/components/TopLeftToolbar.tsx
+++ b/src/components/TopLeftToolbar.tsx
@@ -49,8 +49,9 @@ export const TopLeftToolbar: React.FC = () => {
 	// and overlap with the fixed toolbar.
 	const hiddenPaths = [
 		/^\/character\/[^/]+\/?$/, // character sheet (has its own header back button)
+		/^\/character2(?:\/[^/]+)?\/?$/, // alternative character sheet (has its own menu)
 		/^\/dm\/monsters\/[^/]+\/?$/, // monster designer
-		/^\/dm\/encounters\/[^/]+\/?$/, // encounter planner
+		/^\/dm\/encounters\/[^/]+\/?$/ // encounter planner
 	];
 	if (hiddenPaths.some((re) => re.test(location.pathname))) return null;
 

--- a/src/components/styled.ts
+++ b/src/components/styled.ts
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 // Import static assets
 
 import mainBgImage from '../assets/Main.jpg';
+import { media } from '../styles/responsive';
 
 type StyledMenuVariant = 'character' | 'dm' | 'tools' | 'rulebook';
 
@@ -14,13 +15,17 @@ export const StyledContainer = styled.div`
 	padding: 2rem;
 	background: url('${mainBgImage}') center/cover no-repeat;
 	position: relative;
+
+	${media.mobile} {
+		padding: 1rem;
+	}
 `;
 
 export const StyledTitle = styled.h1`
 	margin-bottom: 0.2rem;
 	color: #fbbf24;
 	text-align: center;
-	font-size: 3rem;
+	font-size: clamp(2rem, 6vw, 3rem);
 	font-weight: bold;
 	font-family: 'Cinzel', 'Georgia', 'Times New Roman', serif;
 	letter-spacing: 2px;
@@ -61,22 +66,22 @@ export const StyledSectionTitle = styled.h3`
 // Character section - Gold/Amber highlight
 export const StyledCharacterGrid = styled.div`
 	display: grid;
-	grid-template-columns: repeat(2, 1fr);
+	grid-template-columns: minmax(0, 1fr);
 	gap: 1rem;
 
-	@media (max-width: 599px) {
-		grid-template-columns: 1fr;
+	${media.tabletUp} {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
 	}
 `;
 
 // DM Tools section - Purple highlight
 export const StyledDMGrid = styled.div`
 	display: grid;
-	grid-template-columns: repeat(2, minmax(0, 1fr));
+	grid-template-columns: minmax(0, 1fr);
 	gap: 1rem;
 
-	@media (max-width: 899px) {
-		grid-template-columns: 1fr;
+	${media.desktop} {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
 	}
 `;
 
@@ -86,38 +91,38 @@ export const StyledDMGroup = styled.div`
 
 export const StyledDMGroupCards = styled.div`
 	display: grid;
-	grid-template-columns: repeat(2, minmax(0, 1fr));
+	grid-template-columns: minmax(0, 1fr);
 	gap: 1rem;
 
-	@media (max-width: 599px) {
-		grid-template-columns: 1fr;
+	${media.tabletUp} {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
 	}
 `;
 
 // Tools section - 4 columns
 export const StyledToolsGrid = styled.div`
 	display: grid;
-	grid-template-columns: repeat(4, 1fr);
+	grid-template-columns: minmax(0, 1fr);
 	row-gap: 1.5rem;
 	column-gap: 1rem;
 
 	& > *:nth-child(5) {
-		grid-column: 2 / span 2;
+		grid-column: auto;
 	}
 
-	@media (max-width: 899px) {
-		grid-template-columns: repeat(2, 1fr);
+	${media.tablet} {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
 
 		& > *:nth-child(5) {
 			grid-column: 1 / -1;
 		}
 	}
 
-	@media (max-width: 599px) {
-		grid-template-columns: 1fr;
+	${media.desktop} {
+		grid-template-columns: repeat(4, minmax(0, 1fr));
 
 		& > *:nth-child(5) {
-			grid-column: auto;
+			grid-column: 2 / span 2;
 		}
 	}
 `;
@@ -125,12 +130,12 @@ export const StyledToolsGrid = styled.div`
 // Old grid for backwards compatibility
 export const StyledMenuGrid = styled.div`
 	display: grid;
-	grid-template-columns: repeat(2, 1fr);
+	grid-template-columns: minmax(0, 1fr);
 	gap: 1.5rem;
 	max-width: 900px;
 	width: 100%;
 
-	@media (min-width: 600px) {
+	${media.tabletUp} {
 		grid-template-columns: repeat(6, 1fr);
 
 		& > *:nth-child(1) {
@@ -148,10 +153,6 @@ export const StyledMenuGrid = styled.div`
 		& > *:nth-child(5) {
 			grid-column: 5 / 7;
 		}
-	}
-
-	@media (max-width: 599px) {
-		grid-template-columns: 1fr;
 	}
 `;
 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -566,6 +566,7 @@
 		"backToMenu": "← Back to Menu",
 		"importFromJson": "📥 Import from JSON",
 		"viewSheet": "View Sheet",
+		"viewAlternativeSheet": "Alternative Sheet",
 		"exportPdf": "Export PDF",
 		"edit": "Edit",
 		"levelUp": "Level Up",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -565,6 +565,7 @@
 		"backToMenu": "← Volver al Menú",
 		"importFromJson": "📥 Importar desde JSON",
 		"viewSheet": "Ver Hoja",
+		"viewAlternativeSheet": "Hoja Alternativa",
 		"exportPdf": "Exportar PDF",
 		"edit": "Editar",
 		"levelUp": "Subir de Nivel",

--- a/src/lib/utils/weaponUtils.ts
+++ b/src/lib/utils/weaponUtils.ts
@@ -5,13 +5,14 @@ import { Weapon, WeaponProperty } from '../rulesdata/inventoryItems';
 
 export interface ParsedDamage {
 	amount: number;
-	type: 'S' | 'P' | 'B' | 'S/P' | 'B/P';
+	type: 'S' | 'P' | 'B' | 'S/P' | 'B/P' | 'B/P/S';
 	typeDisplay:
 		| 'slashing'
 		| 'piercing'
 		| 'bludgeoning'
 		| 'slashing/piercing'
-		| 'bludgeoning/piercing';
+		| 'bludgeoning/piercing'
+		| 'bludgeoning/piercing/slashing';
 }
 
 /**
@@ -43,6 +44,9 @@ export function parseDamage(damageStr: string): ParsedDamage {
 			break;
 		case 'B/P':
 			typeDisplay = 'bludgeoning/piercing';
+			break;
+		case 'B/P/S':
+			typeDisplay = 'bludgeoning/piercing/slashing';
 			break;
 		default:
 			typeDisplay = 'bludgeoning';

--- a/src/routes/character-creation/CharacterCreation.styled.ts
+++ b/src/routes/character-creation/CharacterCreation.styled.ts
@@ -64,8 +64,12 @@ export const HeaderContent = styled.div`
 	margin: 0 auto;
 	width: 100%;
 
+	${media.tablet} {
+		padding: 4.75rem ${theme.spacing[6]} ${theme.spacing[2]};
+	}
+
 	${media.mobile} {
-		padding: ${theme.spacing[2]} ${theme.spacing[4]};
+		padding: 4.25rem ${theme.spacing[4]} ${theme.spacing[2]};
 	}
 `;
 
@@ -102,6 +106,10 @@ export const MobileTitle = styled.span`
 	text-overflow: ellipsis;
 	overflow: hidden;
 	white-space: nowrap;
+
+	${media.mobile} {
+		display: none;
+	}
 
 	${media.desktop} {
 		display: none;

--- a/src/routes/character-creation/ClassSelector.styled.ts
+++ b/src/routes/character-creation/ClassSelector.styled.ts
@@ -93,7 +93,7 @@ export const ClassGrid = styled.div`
 	grid-template-columns: 1fr;
 	gap: ${theme.spacing[6]};
 
-	${media.tabletDown} {
+	${media.tablet} {
 		grid-template-columns: repeat(2, 1fr);
 	}
 

--- a/src/routes/character-creation/LoadCharacter.styled.ts
+++ b/src/routes/character-creation/LoadCharacter.styled.ts
@@ -1,11 +1,18 @@
 import styled from 'styled-components';
 import { motion } from 'framer-motion';
 import { theme, media } from '../character-sheet/styles/theme';
+import { ButtonRow } from '../../components/styled/Container';
 
 /**
  * LoadCharacter Page-Specific Styled Components
  * Shared components (buttons, modals, containers) imported from src/components/styled
  */
+
+export const ImportButtonRow = styled(ButtonRow)`
+	${media.tabletDown} {
+		padding-top: 3.75rem;
+	}
+`;
 
 // Character grid layout
 export const CharacterGrid = styled.div`

--- a/src/routes/character-creation/LoadCharacter.tsx
+++ b/src/routes/character-creation/LoadCharacter.tsx
@@ -136,6 +136,11 @@ function LoadCharacter() {
 		navigate(`/character/${character.id}`);
 	};
 
+	const handleViewAlternativeSheet = (character: SavedCharacter, event: React.MouseEvent) => {
+		event.stopPropagation();
+		navigate(`/character2/${character.id}`);
+	};
+
 	const findCurrentRulesCopy = (character: SavedCharacter, characters = savedCharacters) =>
 		characters.find(
 			(candidate) =>
@@ -649,6 +654,14 @@ function LoadCharacter() {
 										whileTap={{ scale: 0.95 }}
 									>
 										{t('loadCharacter.viewSheet')}
+									</CardButton>
+									<CardButton
+										$variant="secondary"
+										onClick={(e) => handleViewAlternativeSheet(character, e)}
+										whileHover={{ scale: 1.05 }}
+										whileTap={{ scale: 0.95 }}
+									>
+										{t('loadCharacter.viewAlternativeSheet')}
 									</CardButton>
 									<CardButton
 										onClick={(e) => handleExportPdf(character, e)}

--- a/src/routes/character-creation/LoadCharacter.tsx
+++ b/src/routes/character-creation/LoadCharacter.tsx
@@ -25,7 +25,6 @@ import { AnimatePresence } from 'framer-motion';
 import {
 	PageContainer,
 	Header,
-	ButtonRow,
 	PageTitle,
 	EmptyState,
 	EmptyStateTitle,
@@ -57,7 +56,8 @@ import {
 	CardButton,
 	FullWidthButton,
 	CompatibilityBadge,
-	UpgradeSummary
+	UpgradeSummary,
+	ImportButtonRow
 } from './LoadCharacter.styled';
 
 const getCharacterSortTime = (character: SavedCharacter): number => {
@@ -516,7 +516,7 @@ function LoadCharacter() {
 				animate={{ opacity: 1, y: 0 }}
 				transition={{ duration: 0.5 }}
 			>
-				<ButtonRow>
+				<ImportButtonRow>
 					<SuccessButton
 						onClick={handleImportClick}
 						whileHover={{ scale: 1.05 }}
@@ -524,7 +524,7 @@ function LoadCharacter() {
 					>
 						{t('loadCharacter.importFromJson')}
 					</SuccessButton>
-				</ButtonRow>
+				</ImportButtonRow>
 			</Header>
 
 			<PageTitle

--- a/src/routes/character-sheet/CharacterSheetRedesign.styled.ts
+++ b/src/routes/character-sheet/CharacterSheetRedesign.styled.ts
@@ -37,6 +37,11 @@ export const HeaderContent = styled.div`
 	flex-direction: column;
 	align-items: flex-start;
 	gap: ${theme.spacing[4]};
+	min-width: 0;
+
+	${media.mobile} {
+		padding-top: 3.5rem;
+	}
 `;
 
 export const LeftSection = styled.div`
@@ -111,12 +116,18 @@ export const MetaLink = styled(Link)`
 
 export const ActionButtons = styled.div`
 	display: flex;
+	flex-wrap: wrap;
 	gap: ${theme.spacing[3]};
-	/* Leave room for the fixed FixedAuthStatus overlay (≈12rem from right edge) */
-	padding-right: 12rem;
 
 	${media.tablet} {
-		padding-right: 10rem;
+		flex-wrap: nowrap;
+		max-width: 100%;
+		overflow-x: auto;
+		padding-bottom: ${theme.spacing[1]};
+
+		& > * {
+			flex: 0 0 auto;
+		}
 	}
 
 	${media.mobile} {
@@ -182,6 +193,9 @@ export const MainContent = styled.main`
 	max-width: 1600px;
 	margin: 0 auto;
 	padding: ${theme.spacing[8]};
+	width: 100%;
+	box-sizing: border-box;
+	min-width: 0;
 
 	${media.tablet} {
 		padding: ${theme.spacing[6]};
@@ -195,11 +209,11 @@ export const MainContent = styled.main`
 
 export const TwoColumnLayout = styled.div`
 	display: grid;
-	grid-template-columns: 1fr 2fr;
+	grid-template-columns: 280px minmax(0, 1fr);
 	gap: ${theme.spacing[6]};
+	min-width: 0;
 
 	${media.tablet} {
-		grid-template-columns: 280px 1fr;
 		gap: ${theme.spacing[4]};
 	}
 
@@ -213,12 +227,14 @@ export const LeftColumn = styled.div`
 	display: flex;
 	flex-direction: column;
 	gap: ${theme.spacing[6]};
+	min-width: 0;
 `;
 
 export const RightColumn = styled.div`
 	display: flex;
 	flex-direction: column;
 	gap: ${theme.spacing[4]};
+	min-width: 0;
 `;
 
 export const TabContainer = styled.div`
@@ -227,6 +243,8 @@ export const TabContainer = styled.div`
 	box-shadow: ${theme.shadows.lg};
 	overflow: hidden;
 	border: 1px solid ${theme.colors.border.default};
+	container-name: sheet-tabs;
+	container-type: inline-size;
 
 	${media.mobile} {
 		max-width: 100vw;
@@ -292,6 +310,12 @@ export const Tab = styled(motion.button)<{ $active: boolean }>`
 		font-size: ${theme.typography.fontSize.sm};
 	}
 
+	@container sheet-tabs (max-width: 70rem) {
+		padding: ${theme.spacing[3]} ${theme.spacing[2]};
+		gap: ${theme.spacing[1]};
+		font-size: ${theme.typography.fontSize.xs};
+	}
+
 	${(props) =>
 		props.$active &&
 		`
@@ -350,6 +374,7 @@ export const SectionCard = styled(motion.div)<{ $withMarginBottom?: boolean }>`
 	padding: ${theme.spacing[6]};
 	box-shadow: ${theme.shadows.md};
 	border: 1px solid ${theme.colors.border.default};
+	min-width: 0;
 	${(props) => props.$withMarginBottom && `margin-bottom: ${theme.spacing[4]};`}
 `;
 

--- a/src/routes/character-sheet/alternative/AlternativeCharacterSheet.styles.ts
+++ b/src/routes/character-sheet/alternative/AlternativeCharacterSheet.styles.ts
@@ -1,0 +1,243 @@
+import styled from 'styled-components';
+import { Link } from 'react-router-dom';
+import { media, theme } from '../styles/theme';
+
+export const SheetPage = styled.main`
+	min-height: 100vh;
+	background: ${theme.colors.bg.primary};
+	color: ${theme.colors.text.primary};
+	font-family: ${theme.typography.fontFamily.primary};
+	padding: ${theme.spacing[8]};
+
+	${media.tabletDown} {
+		padding: 5.5rem ${theme.spacing[4]} ${theme.spacing[4]};
+	}
+`;
+
+export const SheetContent = styled.div`
+	width: min(100%, 1400px);
+	margin: 0 auto;
+	display: grid;
+	gap: ${theme.spacing[6]};
+`;
+
+export const SheetHeader = styled.header`
+	position: relative;
+	display: grid;
+	grid-template-columns: auto minmax(0, 1fr) auto;
+	align-items: center;
+	gap: ${theme.spacing[5]};
+	padding: ${theme.spacing[6]};
+	padding-right: 14rem;
+	background: ${theme.colors.bg.elevated};
+	border: 1px solid ${theme.colors.border.default};
+	border-radius: ${theme.borderRadius.xl};
+	box-shadow: ${theme.shadows.lg};
+
+	${media.tabletDown} {
+		grid-template-columns: auto minmax(0, 1fr);
+		padding: ${theme.spacing[4]};
+	}
+`;
+
+export const Identity = styled.div`
+	min-width: 0;
+`;
+
+export const CharacterName = styled.h1`
+	margin: 0 0 ${theme.spacing[2]};
+	color: ${theme.colors.text.primary};
+	font-size: clamp(1.5rem, 3vw, ${theme.typography.fontSize['4xl']});
+	line-height: ${theme.typography.lineHeight.tight};
+	overflow-wrap: anywhere;
+`;
+
+export const CharacterMeta = styled.div`
+	display: flex;
+	flex-wrap: wrap;
+	gap: ${theme.spacing[2]} ${theme.spacing[4]};
+	color: ${theme.colors.text.secondary};
+	font-size: ${theme.typography.fontSize.base};
+`;
+
+export const MetaLink = styled(Link)`
+	color: inherit;
+	text-decoration-color: ${theme.colors.border.default};
+	text-underline-offset: 0.2em;
+
+	&:hover,
+	&:focus-visible {
+		color: ${theme.colors.accent.primary};
+		text-decoration-color: currentColor;
+	}
+`;
+
+export const HeaderActions = styled.div`
+	display: flex;
+	align-items: center;
+	gap: ${theme.spacing[3]};
+
+	${media.tabletDown} {
+		grid-column: 1 / -1;
+		justify-content: flex-end;
+	}
+`;
+
+export const SheetButton = styled.button`
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	gap: ${theme.spacing[2]};
+	min-height: 42px;
+	padding: ${theme.spacing[2]} ${theme.spacing[4]};
+	background: ${theme.colors.bg.tertiary};
+	color: ${theme.colors.text.primary};
+	border: 1px solid ${theme.colors.border.default};
+	border-radius: ${theme.borderRadius.md};
+	font: inherit;
+	font-size: ${theme.typography.fontSize.sm};
+	font-weight: ${theme.typography.fontWeight.medium};
+	cursor: pointer;
+	transition: all ${theme.transitions.fast};
+
+	&:hover:not(:disabled),
+	&:focus-visible {
+		background: ${theme.colors.accent.primary};
+		border-color: ${theme.colors.accent.primary};
+		color: ${theme.colors.text.inverse};
+	}
+
+	&:disabled {
+		cursor: not-allowed;
+		opacity: 0.5;
+	}
+`;
+
+export const ActionMenu = styled.details`
+	position: relative;
+
+	& > summary {
+		list-style: none;
+	}
+
+	& > summary::-webkit-details-marker {
+		display: none;
+	}
+`;
+
+export const MenuTrigger = styled.summary`
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	min-width: 44px;
+	min-height: 42px;
+	padding: ${theme.spacing[2]} ${theme.spacing[3]};
+	background: ${theme.colors.bg.tertiary};
+	color: ${theme.colors.text.primary};
+	border: 1px solid ${theme.colors.border.default};
+	border-radius: ${theme.borderRadius.md};
+	font-size: ${theme.typography.fontSize.lg};
+	cursor: pointer;
+	transition: all ${theme.transitions.fast};
+
+	&:hover,
+	&:focus-visible {
+		background: ${theme.colors.accent.primary};
+		border-color: ${theme.colors.accent.primary};
+		color: ${theme.colors.text.inverse};
+	}
+`;
+
+export const ExportTrigger = styled(MenuTrigger)`
+	min-width: auto;
+	padding-inline: ${theme.spacing[4]};
+	font-size: ${theme.typography.fontSize.sm};
+	font-weight: ${theme.typography.fontWeight.medium};
+`;
+
+export const MenuPanel = styled.nav<{ $align?: 'left' | 'right' }>`
+	position: absolute;
+	top: calc(100% + ${theme.spacing[2]});
+	${({ $align = 'left' }) => ($align === 'right' ? 'right: 0;' : 'left: 0;')}
+	z-index: ${theme.zIndex.dropdown};
+	display: grid;
+	gap: ${theme.spacing[1]};
+	width: max-content;
+	min-width: 210px;
+	max-height: min(70vh, 560px);
+	overflow-y: auto;
+	padding: ${theme.spacing[2]};
+	background: ${theme.colors.bg.elevated};
+	border: 1px solid ${theme.colors.border.default};
+	border-radius: ${theme.borderRadius.md};
+	box-shadow: ${theme.shadows.xl};
+`;
+
+export const MenuLink = styled(Link)`
+	padding: ${theme.spacing[2]} ${theme.spacing[3]};
+	border-radius: ${theme.borderRadius.sm};
+	color: ${theme.colors.text.primary};
+	text-decoration: none;
+	white-space: nowrap;
+
+	&:hover,
+	&:focus-visible {
+		background: ${theme.colors.bg.tertiary};
+		color: ${theme.colors.accent.primary};
+	}
+`;
+
+export const MenuAction = styled.button`
+	padding: ${theme.spacing[2]} ${theme.spacing[3]};
+	background: transparent;
+	border: 0;
+	border-radius: ${theme.borderRadius.sm};
+	color: ${theme.colors.text.primary};
+	font: inherit;
+	text-align: left;
+	white-space: nowrap;
+	cursor: pointer;
+
+	&:hover,
+	&:focus-visible {
+		background: ${theme.colors.bg.tertiary};
+		color: ${theme.colors.accent.primary};
+	}
+`;
+
+export const ResourceSection = styled.section`
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+	gap: ${theme.spacing[3]};
+	padding: ${theme.spacing[6]};
+	background: ${theme.colors.bg.elevated};
+	border: 1px solid ${theme.colors.border.default};
+	border-radius: ${theme.borderRadius.xl};
+	box-shadow: ${theme.shadows.lg};
+
+	${media.mobile} {
+		grid-template-columns: 1fr;
+		padding: ${theme.spacing[4]};
+	}
+`;
+
+export const ResourceCardSlot = styled.div`
+	min-width: 0;
+	height: 100%;
+
+	& > div {
+		height: 100%;
+	}
+`;
+
+export const PageMessage = styled.div<{ $error?: boolean }>`
+	width: min(100%, 680px);
+	margin: 20vh auto 0;
+	padding: ${theme.spacing[6]};
+	background: ${theme.colors.bg.elevated};
+	border: 1px solid
+		${({ $error }) => ($error ? theme.colors.accent.danger : theme.colors.border.default)};
+	border-radius: ${theme.borderRadius.lg};
+	color: ${({ $error }) => ($error ? theme.colors.accent.danger : theme.colors.text.secondary)};
+	text-align: center;
+`;

--- a/src/routes/character-sheet/alternative/AlternativeCharacterSheet.tsx
+++ b/src/routes/character-sheet/alternative/AlternativeCharacterSheet.tsx
@@ -1,10 +1,13 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import Snackbar, { type SnackbarVariant } from '../../../components/Snackbar';
 import { useAppAuth } from '../../../components/auth/AuthModeContext';
 import { downloadCharacterPdf } from '../../../lib/pdf/exportPdf';
+import { getDiceModifierForAction } from '../../../lib/services/conditionEffectsAnalyzer';
 import { getDefaultStorage } from '../../../lib/storage';
 import { getRulebookArticle, getRulebookArticlePath } from '../../rulebook/rulebookData';
+import { HealthStatusIndicator } from '../components/DeathExhaustion';
+import DiceRoller, { type DiceRollerRef } from '../components/DiceRoller';
 import { StatCard } from '../components/new/StatCard';
 import {
 	useCharacterCalculatedData,
@@ -31,6 +34,9 @@ import {
 	SheetHeader,
 	SheetPage
 } from './AlternativeCharacterSheet.styles';
+import AlternativeCombatResourceSection from './AlternativeCombatResourceSection';
+import AlternativeMasterySection, { type RollActionType } from './AlternativeMasterySection';
+import AlternativeTabbedContent from './AlternativeTabbedContent';
 
 interface Feedback {
 	message: string;
@@ -54,10 +60,12 @@ export default function AlternativeCharacterSheet() {
 		updateGritPoints,
 		updateRestPoints,
 		updateExhaustion,
+		handleDiceRoll,
 		handleLongRestEvent
 	} = useCharacterSheet();
 	const resources = useCharacterResources();
 	const calculatedData = useCharacterCalculatedData();
+	const diceRollerRef = useRef<DiceRollerRef>(null);
 	const [feedback, setFeedback] = useState<Feedback | null>(null);
 
 	if (state.loading) {
@@ -93,6 +101,17 @@ export default function AlternativeCharacterSheet() {
 	const maxRest = calculatedData?.breakdowns?.restPoints?.total ?? character.finalRestPoints ?? 0;
 	const currentGrit = resources?.current.currentGritPoints ?? 0;
 	const maxGrit = calculatedData?.breakdowns?.gritPoints?.total ?? character.finalGritPoints ?? 0;
+	const attackBonus =
+		calculatedData?.stats?.finalAttackSpellCheck ?? character.finalAttackSpellCheck ?? 0;
+	const saveDC = calculatedData?.stats?.finalSaveDC ?? character.finalSaveDC ?? 0;
+	const initiative =
+		calculatedData?.stats?.finalInitiativeBonus ?? character.finalInitiativeBonus ?? 0;
+	const moveSpeed = calculatedData?.stats?.finalMoveSpeed ?? character.finalMoveSpeed ?? 0;
+	const jumpDistance = calculatedData?.stats?.finalJumpDistance ?? character.finalJumpDistance ?? 0;
+	const precisionDefense = calculatedData?.stats?.finalPD ?? character.finalPD ?? 0;
+	const areaDefense = calculatedData?.stats?.finalAD ?? character.finalAD ?? 0;
+	const physicalDamageReduction = calculatedData?.stats?.finalPDR ?? character.finalPDR ?? 0;
+	const resistances = calculatedData?.resistances ?? character.resistances ?? [];
 
 	const classPath = getArticlePath(`classes/${character.classId}`);
 	const ancestry1Path = getArticlePath(
@@ -168,6 +187,16 @@ export default function AlternativeCharacterSheet() {
 		}
 	};
 
+	const handleActionRoll = (label: string, bonus: number, actionType: RollActionType) => {
+		const activeConditions = character.characterState?.activeConditions ?? [];
+		const diceModifier = getDiceModifierForAction(activeConditions, actionType);
+		diceRollerRef.current?.addRollWithModifier(
+			bonus - diceModifier.penalty,
+			label,
+			diceModifier.mode
+		);
+	};
+
 	return (
 		<SheetPage>
 			<SheetContent>
@@ -206,13 +235,6 @@ export default function AlternativeCharacterSheet() {
 							<span>
 								{t('characterSheet.level')} {character.level || 1}
 							</span>
-							{classPath ? (
-								<MetaLink to={classPath}>
-									{character.className || t('characterSheet.adventurer')}
-								</MetaLink>
-							) : (
-								<span>{character.className || t('characterSheet.adventurer')}</span>
-							)}
 							{ancestry1Path ? (
 								<MetaLink to={ancestry1Path}>
 									{character.ancestry1Name || t('characterSheet.unknown')}
@@ -226,6 +248,13 @@ export default function AlternativeCharacterSheet() {
 								) : (
 									<span>{ancestry2Name}</span>
 								))}
+							{classPath ? (
+								<MetaLink to={classPath}>
+									{character.className || t('characterSheet.adventurer')}
+								</MetaLink>
+							) : (
+								<span>{character.className || t('characterSheet.adventurer')}</span>
+							)}
 						</CharacterMeta>
 					</Identity>
 
@@ -268,6 +297,9 @@ export default function AlternativeCharacterSheet() {
 							editable={!readOnly}
 							onChange={updateHP}
 							onTempChange={updateTempHP}
+							afterLabel={<HealthStatusIndicator isMobile={false} />}
+							reserveAfterLabelSpace
+							animateOnMount={false}
 						/>
 					</ResourceCardSlot>
 					{maxMP > 0 && (
@@ -280,6 +312,8 @@ export default function AlternativeCharacterSheet() {
 								size="medium"
 								editable={!readOnly}
 								onChange={updateMP}
+								reserveAfterLabelSpace
+								animateOnMount={false}
 							/>
 						</ResourceCardSlot>
 					)}
@@ -293,6 +327,8 @@ export default function AlternativeCharacterSheet() {
 								size="medium"
 								editable={!readOnly}
 								onChange={updateSP}
+								reserveAfterLabelSpace
+								animateOnMount={false}
 							/>
 						</ResourceCardSlot>
 					)}
@@ -305,6 +341,8 @@ export default function AlternativeCharacterSheet() {
 							size="medium"
 							editable={!readOnly}
 							onChange={updateRestPoints}
+							reserveAfterLabelSpace
+							animateOnMount={false}
 						/>
 					</ResourceCardSlot>
 					<ResourceCardSlot>
@@ -316,11 +354,31 @@ export default function AlternativeCharacterSheet() {
 							size="medium"
 							editable={!readOnly}
 							onChange={updateGritPoints}
+							reserveAfterLabelSpace
+							animateOnMount={false}
 						/>
 					</ResourceCardSlot>
 				</ResourceSection>
+
+				<AlternativeMasterySection onRoll={handleActionRoll} />
+
+				<AlternativeCombatResourceSection
+					attackBonus={attackBonus}
+					saveDC={saveDC}
+					initiative={initiative}
+					moveSpeed={moveSpeed}
+					jumpDistance={jumpDistance}
+					precisionDefense={precisionDefense}
+					areaDefense={areaDefense}
+					physicalDamageReduction={physicalDamageReduction}
+					resistances={resistances}
+					onRoll={handleActionRoll}
+				/>
+
+				<AlternativeTabbedContent />
 			</SheetContent>
 
+			<DiceRoller ref={diceRollerRef} onRoll={handleDiceRoll} />
 			<Snackbar
 				message={feedback?.message ?? ''}
 				isVisible={feedback !== null}

--- a/src/routes/character-sheet/alternative/AlternativeCharacterSheet.tsx
+++ b/src/routes/character-sheet/alternative/AlternativeCharacterSheet.tsx
@@ -1,0 +1,332 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import Snackbar, { type SnackbarVariant } from '../../../components/Snackbar';
+import { useAppAuth } from '../../../components/auth/AuthModeContext';
+import { downloadCharacterPdf } from '../../../lib/pdf/exportPdf';
+import { getDefaultStorage } from '../../../lib/storage';
+import { getRulebookArticle, getRulebookArticlePath } from '../../rulebook/rulebookData';
+import { StatCard } from '../components/new/StatCard';
+import {
+	useCharacterCalculatedData,
+	useCharacterResources,
+	useCharacterSheet
+} from '../hooks/CharacterSheetProvider';
+import {
+	ActionMenu,
+	CharacterMeta,
+	CharacterName,
+	ExportTrigger,
+	HeaderActions,
+	Identity,
+	MenuAction,
+	MenuLink,
+	MenuPanel,
+	MenuTrigger,
+	MetaLink,
+	PageMessage,
+	ResourceCardSlot,
+	ResourceSection,
+	SheetButton,
+	SheetContent,
+	SheetHeader,
+	SheetPage
+} from './AlternativeCharacterSheet.styles';
+
+interface Feedback {
+	message: string;
+	variant: SnackbarVariant;
+}
+
+function getArticlePath(articleId?: string): string | undefined {
+	return articleId && getRulebookArticle(articleId) ? getRulebookArticlePath(articleId) : undefined;
+}
+
+export default function AlternativeCharacterSheet() {
+	const { t } = useTranslation();
+	const { isAuthenticated, isConvexEnabled } = useAppAuth();
+	const {
+		state,
+		readOnly,
+		updateHP,
+		updateMP,
+		updateSP,
+		updateTempHP,
+		updateGritPoints,
+		updateRestPoints,
+		updateExhaustion,
+		handleLongRestEvent
+	} = useCharacterSheet();
+	const resources = useCharacterResources();
+	const calculatedData = useCharacterCalculatedData();
+	const [feedback, setFeedback] = useState<Feedback | null>(null);
+
+	if (state.loading) {
+		return (
+			<SheetPage>
+				<PageMessage>{t('characterSheet.loading')}</PageMessage>
+			</SheetPage>
+		);
+	}
+
+	const character = state.character;
+	if (state.error || !character) {
+		return (
+			<SheetPage>
+				<PageMessage $error>{state.error || t('characterSheet.notFound')}</PageMessage>
+			</SheetPage>
+		);
+	}
+
+	const currentHP = resources?.current.currentHP ?? 0;
+	const maxHP = calculatedData?.breakdowns?.hpMax?.total ?? character.finalHPMax ?? 0;
+	const minHP = -(
+		calculatedData?.stats?.finalDeathThreshold ??
+		character.finalDeathThreshold ??
+		character.finalPrimeModifierValue + character.finalCombatMastery
+	);
+	const tempHP = resources?.current.tempHP ?? 0;
+	const currentMP = resources?.current.currentMP ?? 0;
+	const maxMP = calculatedData?.breakdowns?.mpMax?.total ?? character.finalMPMax ?? 0;
+	const currentSP = resources?.current.currentSP ?? 0;
+	const maxSP = calculatedData?.breakdowns?.spMax?.total ?? character.finalSPMax ?? 0;
+	const currentRest = resources?.current.currentRestPoints ?? 0;
+	const maxRest = calculatedData?.breakdowns?.restPoints?.total ?? character.finalRestPoints ?? 0;
+	const currentGrit = resources?.current.currentGritPoints ?? 0;
+	const maxGrit = calculatedData?.breakdowns?.gritPoints?.total ?? character.finalGritPoints ?? 0;
+
+	const classPath = getArticlePath(`classes/${character.classId}`);
+	const ancestry1Path = getArticlePath(
+		character.ancestry1Id ? `ancestries/${character.ancestry1Id}` : undefined
+	);
+	const ancestry2Path = getArticlePath(
+		character.ancestry2Id ? `ancestries/${character.ancestry2Id}` : undefined
+	);
+	const ancestry2Name =
+		character.ancestry2Name?.trim().toLowerCase() === 'unknown'
+			? undefined
+			: character.ancestry2Name?.trim();
+
+	const showFeedback = (message: string, variant: SnackbarVariant) => {
+		setFeedback({ message, variant });
+	};
+
+	const handleLongRest = () => {
+		if (!window.confirm(t('characterSheet.longRestConfirm'))) return;
+		updateHP(maxHP);
+		updateMP(maxMP);
+		updateSP(maxSP);
+		updateRestPoints(maxRest);
+		updateTempHP(0);
+		updateExhaustion(0);
+		handleLongRestEvent();
+		showFeedback(t('characterSheet.longRestDone'), 'success');
+	};
+
+	const handleExportPdf = async () => {
+		try {
+			const storedCharacter =
+				(await getDefaultStorage().getCharacterById(character.id)) ?? character;
+			await downloadCharacterPdf(storedCharacter);
+		} catch (exportError) {
+			showFeedback(
+				`Failed to export PDF: ${
+					exportError instanceof Error ? exportError.message : String(exportError)
+				}`,
+				'error'
+			);
+		}
+	};
+
+	const handleDownloadJson = () => {
+		// Export serialization only; character state remains a native object in context.
+		// eslint-disable-next-line no-restricted-syntax
+		const json = JSON.stringify(character, null, 2);
+		const blob = new Blob([json], { type: 'application/json' });
+		const safeName = (character.finalName || character.id || 'Character')
+			.replace(/[^A-Za-z0-9]+/g, '_')
+			.replace(/^_+|_+$/g, '')
+			.slice(0, 60);
+		const url = URL.createObjectURL(blob);
+		const anchor = document.createElement('a');
+		anchor.href = url;
+		anchor.download = `${safeName || 'Character'}.json`;
+		document.body.appendChild(anchor);
+		anchor.click();
+		document.body.removeChild(anchor);
+		URL.revokeObjectURL(url);
+		showFeedback('Character JSON downloaded.', 'success');
+	};
+
+	const handleCopyJson = async () => {
+		try {
+			// Export serialization only; character state remains a native object in context.
+			// eslint-disable-next-line no-restricted-syntax
+			await navigator.clipboard.writeText(JSON.stringify(character, null, 2));
+			showFeedback('Character JSON copied to clipboard.', 'success');
+		} catch {
+			showFeedback('Failed to copy character JSON.', 'error');
+		}
+	};
+
+	return (
+		<SheetPage>
+			<SheetContent>
+				<SheetHeader>
+					<ActionMenu>
+						<MenuTrigger aria-label="Open main navigation">☰</MenuTrigger>
+						<MenuPanel aria-label="Main navigation">
+							<MenuLink to="/menu">Menu</MenuLink>
+							<MenuLink to="/create-character">{t('menu.createCharacter')}</MenuLink>
+							<MenuLink to="/load-character">{t('menu.loadCharacter')}</MenuLink>
+							<MenuLink to="/spellbook">{t('menu.spellbook')}</MenuLink>
+							<MenuLink to="/martial-manual">{t('menu.martialManual')}</MenuLink>
+							<MenuLink to="/conditions">{t('menu.conditions')}</MenuLink>
+							<MenuLink to="/custom-equipment">{t('menu.equipage')}</MenuLink>
+							<MenuLink to="/rulebook">{t('menu.rulebook')}</MenuLink>
+							{isAuthenticated && (
+								<>
+									<MenuLink to="/dm/encounters">{t('menu.encounterPlanner')}</MenuLink>
+									<MenuLink to="/dm/monsters">{t('menu.laboratory')}</MenuLink>
+								</>
+							)}
+							{isAuthenticated && isConvexEnabled && (
+								<>
+									<MenuLink to="/campaigns">{t('menu.myCampaigns')}</MenuLink>
+									<MenuLink to="/campaigns/join">{t('menu.joinCampaign')}</MenuLink>
+								</>
+							)}
+						</MenuPanel>
+					</ActionMenu>
+
+					<Identity>
+						<CharacterName>
+							{character.finalName || t('characterSheet.unnamedCharacter')}
+						</CharacterName>
+						<CharacterMeta>
+							<span>
+								{t('characterSheet.level')} {character.level || 1}
+							</span>
+							{classPath ? (
+								<MetaLink to={classPath}>
+									{character.className || t('characterSheet.adventurer')}
+								</MetaLink>
+							) : (
+								<span>{character.className || t('characterSheet.adventurer')}</span>
+							)}
+							{ancestry1Path ? (
+								<MetaLink to={ancestry1Path}>
+									{character.ancestry1Name || t('characterSheet.unknown')}
+								</MetaLink>
+							) : (
+								<span>{character.ancestry1Name || t('characterSheet.unknown')}</span>
+							)}
+							{ancestry2Name &&
+								(ancestry2Path ? (
+									<MetaLink to={ancestry2Path}>{ancestry2Name}</MetaLink>
+								) : (
+									<span>{ancestry2Name}</span>
+								))}
+						</CharacterMeta>
+					</Identity>
+
+					<HeaderActions>
+						<SheetButton
+							type="button"
+							onClick={handleLongRest}
+							disabled={readOnly}
+							title={t('characterSheet.longRestTitle')}
+						>
+							🌙 {t('characterSheet.longRest')}
+						</SheetButton>
+						<ActionMenu>
+							<ExportTrigger>{t('characterSheet.export')}</ExportTrigger>
+							<MenuPanel $align="right" aria-label="Export character">
+								<MenuAction type="button" onClick={handleExportPdf}>
+									{t('characterSheet.exportPdf')}
+								</MenuAction>
+								<MenuAction type="button" onClick={handleDownloadJson}>
+									{t('characterSheet.downloadJson')}
+								</MenuAction>
+								<MenuAction type="button" onClick={handleCopyJson}>
+									Copy to Clipboard
+								</MenuAction>
+							</MenuPanel>
+						</ActionMenu>
+					</HeaderActions>
+				</SheetHeader>
+
+				<ResourceSection aria-label="Character resources">
+					<ResourceCardSlot>
+						<StatCard
+							label="HP"
+							current={currentHP}
+							max={maxHP}
+							min={minHP}
+							temp={tempHP}
+							color="health"
+							size="medium"
+							editable={!readOnly}
+							onChange={updateHP}
+							onTempChange={updateTempHP}
+						/>
+					</ResourceCardSlot>
+					{maxMP > 0 && (
+						<ResourceCardSlot>
+							<StatCard
+								label="Mana"
+								current={currentMP}
+								max={maxMP}
+								color="mana"
+								size="medium"
+								editable={!readOnly}
+								onChange={updateMP}
+							/>
+						</ResourceCardSlot>
+					)}
+					{maxSP > 0 && (
+						<ResourceCardSlot>
+							<StatCard
+								label="Stamina"
+								current={currentSP}
+								max={maxSP}
+								color="stamina"
+								size="medium"
+								editable={!readOnly}
+								onChange={updateSP}
+							/>
+						</ResourceCardSlot>
+					)}
+					<ResourceCardSlot>
+						<StatCard
+							label="Rest"
+							current={currentRest}
+							max={maxRest}
+							color="grit"
+							size="medium"
+							editable={!readOnly}
+							onChange={updateRestPoints}
+						/>
+					</ResourceCardSlot>
+					<ResourceCardSlot>
+						<StatCard
+							label="Grit"
+							current={currentGrit}
+							max={maxGrit}
+							color="grit"
+							size="medium"
+							editable={!readOnly}
+							onChange={updateGritPoints}
+						/>
+					</ResourceCardSlot>
+				</ResourceSection>
+			</SheetContent>
+
+			<Snackbar
+				message={feedback?.message ?? ''}
+				isVisible={feedback !== null}
+				variant={feedback?.variant}
+				onClose={() => setFeedback(null)}
+			/>
+		</SheetPage>
+	);
+}

--- a/src/routes/character-sheet/alternative/AlternativeCharacterSheetRouter.test.ts
+++ b/src/routes/character-sheet/alternative/AlternativeCharacterSheetRouter.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import type { SavedCharacter } from '../../../lib/types/dataContracts';
+import { selectMostRecentlyModifiedCharacter } from './AlternativeCharacterSheetRouter';
+
+function character(id: string, lastModified: string): SavedCharacter {
+	return {
+		id,
+		lastModified,
+		completedAt: lastModified,
+		createdAt: lastModified
+	} as SavedCharacter;
+}
+
+describe('selectMostRecentlyModifiedCharacter', () => {
+	it('selects the latest saved character without changing the input order', () => {
+		const characters = [
+			character('older', '2026-01-01T00:00:00.000Z'),
+			character('newer', '2026-07-24T00:00:00.000Z')
+		];
+
+		expect(selectMostRecentlyModifiedCharacter(characters)?.id).toBe('newer');
+		expect(characters.map(({ id }) => id)).toEqual(['older', 'newer']);
+	});
+
+	it('returns null for an empty character list', () => {
+		expect(selectMostRecentlyModifiedCharacter([])).toBeNull();
+	});
+});

--- a/src/routes/character-sheet/alternative/AlternativeCharacterSheetRouter.tsx
+++ b/src/routes/character-sheet/alternative/AlternativeCharacterSheetRouter.tsx
@@ -1,0 +1,88 @@
+import { useEffect, useState } from 'react';
+import type { SavedCharacter } from '../../../lib/types/dataContracts';
+import { getDefaultStorage } from '../../../lib/storage';
+import { CharacterSheetProvider } from '../hooks/CharacterSheetProvider';
+import AlternativeCharacterSheet from './AlternativeCharacterSheet';
+import { PageMessage, SheetPage } from './AlternativeCharacterSheet.styles';
+
+interface AlternativeCharacterSheetRouterProps {
+	characterId?: string;
+}
+
+export function selectMostRecentlyModifiedCharacter(
+	characters: SavedCharacter[]
+): SavedCharacter | null {
+	return (
+		[...characters].sort((left, right) => {
+			const leftTime = Date.parse(left.lastModified || left.completedAt || left.createdAt);
+			const rightTime = Date.parse(right.lastModified || right.completedAt || right.createdAt);
+			return (Number.isNaN(rightTime) ? 0 : rightTime) - (Number.isNaN(leftTime) ? 0 : leftTime);
+		})[0] ?? null
+	);
+}
+
+function AlternativeCharacterSheetWithProvider({ characterId }: { characterId: string }) {
+	return (
+		<CharacterSheetProvider characterId={characterId}>
+			<AlternativeCharacterSheet />
+		</CharacterSheetProvider>
+	);
+}
+
+export default function AlternativeCharacterSheetRouter({
+	characterId
+}: AlternativeCharacterSheetRouterProps) {
+	const [resolvedId, setResolvedId] = useState<string | null>(characterId ?? null);
+	const [error, setError] = useState<string | null>(null);
+
+	useEffect(() => {
+		if (characterId) {
+			setResolvedId(characterId);
+			setError(null);
+			return;
+		}
+
+		let cancelled = false;
+		getDefaultStorage()
+			.getAllCharacters()
+			.then((characters) => {
+				if (cancelled) return;
+				const latestCharacter = selectMostRecentlyModifiedCharacter(characters);
+				if (latestCharacter) {
+					setResolvedId(latestCharacter.id);
+				} else {
+					setError('No saved characters found.');
+				}
+			})
+			.catch((loadError) => {
+				if (cancelled) return;
+				setError(
+					`Failed to load characters: ${
+						loadError instanceof Error ? loadError.message : String(loadError)
+					}`
+				);
+			});
+
+		return () => {
+			cancelled = true;
+		};
+	}, [characterId]);
+
+	if (error) {
+		return (
+			<SheetPage>
+				<PageMessage $error>{error}</PageMessage>
+			</SheetPage>
+		);
+	}
+
+	if (!resolvedId) {
+		return (
+			<SheetPage>
+				<PageMessage>Loading character...</PageMessage>
+			</SheetPage>
+		);
+	}
+
+	return <AlternativeCharacterSheetWithProvider characterId={resolvedId} />;
+}

--- a/src/routes/character-sheet/alternative/AlternativeCombatResourceSection.styles.ts
+++ b/src/routes/character-sheet/alternative/AlternativeCombatResourceSection.styles.ts
@@ -1,0 +1,328 @@
+import styled, { css } from 'styled-components';
+import { media, theme } from '../styles/theme';
+
+export const CombatResourceSection = styled.section`
+	display: grid;
+	grid-template-columns: minmax(280px, 0.65fr) minmax(0, 1.35fr);
+	align-items: stretch;
+	gap: ${theme.spacing[3]};
+	padding: ${theme.spacing[4]};
+	background: ${theme.colors.bg.elevated};
+	border: 1px solid ${theme.colors.border.default};
+	border-radius: ${theme.borderRadius.xl};
+	box-shadow: ${theme.shadows.lg};
+
+	@media (max-width: 1200px) {
+		grid-template-columns: minmax(260px, 0.7fr) minmax(0, 1.3fr);
+	}
+
+	@media (max-width: 900px) {
+		grid-template-columns: 1fr;
+	}
+
+	${media.mobile} {
+		padding: ${theme.spacing[4]};
+	}
+`;
+
+const panelStyles = css`
+	min-width: 0;
+	padding: ${theme.spacing[3]};
+	background: ${theme.colors.bg.secondary};
+	border: 1px solid ${theme.colors.border.default};
+	border-radius: ${theme.borderRadius.lg};
+	box-shadow: ${theme.shadows.md};
+`;
+
+export const ActionPanel = styled.div`
+	${panelStyles}
+	display: grid;
+	align-content: start;
+	gap: ${theme.spacing[2]};
+`;
+
+export const AttackButton = styled.button`
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) auto;
+	align-items: center;
+	gap: ${theme.spacing[2]};
+	min-height: 72px;
+	padding: ${theme.spacing[3]} ${theme.spacing[4]};
+	background: linear-gradient(
+		135deg,
+		${theme.colors.bg.tertiary},
+		${theme.colors.accent.infoAlpha20}
+	);
+	border: 1px solid ${theme.colors.accent.primary};
+	border-radius: ${theme.borderRadius.lg};
+	color: ${theme.colors.text.primary};
+	font: inherit;
+	cursor: pointer;
+	transition: all ${theme.transitions.fast};
+	box-shadow: 0 10px 24px rgba(125, 207, 255, 0.08);
+	text-align: left;
+
+	&:hover,
+	&:focus-visible {
+		transform: translateY(-2px);
+		box-shadow: 0 12px 28px rgba(125, 207, 255, 0.16);
+	}
+`;
+
+export const ActionCopy = styled.span`
+	display: grid;
+	gap: 2px;
+`;
+
+export const ActionEyebrow = styled.span`
+	color: ${theme.colors.accent.primary};
+	font-size: ${theme.typography.fontSize.xs};
+	font-weight: ${theme.typography.fontWeight.bold};
+	text-transform: uppercase;
+	letter-spacing: 0.08em;
+`;
+
+export const ActionLabel = styled.span`
+	color: ${theme.colors.text.primary};
+	font-size: ${theme.typography.fontSize.lg};
+	font-weight: ${theme.typography.fontWeight.bold};
+`;
+
+export const ActionValue = styled.span`
+	color: ${theme.colors.accent.primary};
+	font-size: ${theme.typography.fontSize['3xl']};
+	font-weight: ${theme.typography.fontWeight.bold};
+	line-height: ${theme.typography.lineHeight.tight};
+	font-variant-numeric: tabular-nums;
+`;
+
+export const TacticalGrid = styled.div`
+	display: grid;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	gap: ${theme.spacing[2]};
+`;
+
+const tacticalMetricStyles = css`
+	display: grid;
+	justify-items: start;
+	gap: ${theme.spacing[1]};
+	min-height: 64px;
+	padding: ${theme.spacing[2]} ${theme.spacing[3]};
+	background: ${theme.colors.bg.primary};
+	border: 1px solid ${theme.colors.border.default};
+	border-radius: ${theme.borderRadius.md};
+	color: ${theme.colors.text.primary};
+	font: inherit;
+	text-align: left;
+`;
+
+export const TacticalMetric = styled.div`
+	${tacticalMetricStyles}
+`;
+
+export const TacticalButton = styled.button`
+	${tacticalMetricStyles}
+	cursor: pointer;
+	transition: all ${theme.transitions.fast};
+
+	&:hover,
+	&:focus-visible {
+		background: ${theme.colors.bg.tertiary};
+		border-color: ${theme.colors.accent.primary};
+		transform: translateY(-1px);
+	}
+`;
+
+export const MetricLabel = styled.span`
+	color: ${theme.colors.text.secondary};
+	font-size: ${theme.typography.fontSize.xs};
+	font-weight: ${theme.typography.fontWeight.semibold};
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+`;
+
+export const MetricValue = styled.span<{ $actionable?: boolean }>`
+	color: ${({ $actionable }) =>
+		$actionable ? theme.colors.accent.primary : theme.colors.text.primary};
+	font-size: ${theme.typography.fontSize.lg};
+	font-weight: ${theme.typography.fontWeight.bold};
+	font-variant-numeric: tabular-nums;
+`;
+
+export const DefensePanel = styled.div`
+	${panelStyles}
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) auto;
+	align-items: stretch;
+	gap: ${theme.spacing[4]};
+
+	@media (max-width: 1200px) {
+		grid-column: auto;
+	}
+
+	${media.mobile} {
+		grid-template-columns: 1fr;
+	}
+`;
+
+export const DefenseCards = styled.div`
+	display: grid;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	gap: ${theme.spacing[3]};
+
+	${media.mobile} {
+		grid-template-columns: 1fr;
+	}
+`;
+
+export const DefenseCard = styled.div<{ $color: string }>`
+	display: grid;
+	align-content: start;
+	gap: ${theme.spacing[3]};
+	min-width: 0;
+	padding: ${theme.spacing[3]};
+	background: ${theme.colors.bg.primary};
+	border: 1px solid ${theme.colors.border.default};
+	border-top: 3px solid ${({ $color }) => $color};
+	border-radius: ${theme.borderRadius.lg};
+`;
+
+export const DefenseTitle = styled.h3<{ $color: string }>`
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: ${theme.spacing[2]};
+	margin: 0;
+	color: ${({ $color }) => $color};
+	font-size: ${theme.typography.fontSize.base};
+	font-weight: ${theme.typography.fontWeight.bold};
+	line-height: ${theme.typography.lineHeight.tight};
+`;
+
+export const DefenseAbbreviation = styled.span<{ $color: string }>`
+	flex: 0 0 auto;
+	padding: 2px ${theme.spacing[2]};
+	background: ${({ $color }) => `color-mix(in srgb, ${$color} 16%, transparent)`};
+	border: 1px solid ${({ $color }) => $color};
+	border-radius: ${theme.borderRadius.full};
+	color: ${({ $color }) => $color};
+	font-size: ${theme.typography.fontSize.xs};
+	font-weight: ${theme.typography.fontWeight.bold};
+	letter-spacing: 0.06em;
+`;
+
+export const DefenseThresholds = styled.div`
+	display: grid;
+	gap: ${theme.spacing[2]};
+`;
+
+const defenseThresholdColor = {
+	hit: theme.colors.text.primary,
+	heavy: theme.colors.text.secondary,
+	brutal: `color-mix(in srgb, ${theme.colors.text.muted} 60%, ${theme.colors.text.secondary})`
+} as const;
+
+type DefenseThresholdTone = keyof typeof defenseThresholdColor;
+
+const defenseThresholdLabelSize: Record<DefenseThresholdTone, string> = {
+	hit: theme.typography.fontSize.base,
+	heavy: theme.typography.fontSize.sm,
+	brutal: theme.typography.fontSize.xs
+};
+
+const defenseThresholdValueSize: Record<DefenseThresholdTone, string> = {
+	hit: theme.typography.fontSize['2xl'],
+	heavy: theme.typography.fontSize.lg,
+	brutal: theme.typography.fontSize.base
+};
+
+export const DefenseThreshold = styled.div<{ $tone: DefenseThresholdTone }>`
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) auto;
+	align-items: baseline;
+	gap: ${theme.spacing[2]};
+	color: ${({ $tone }) => defenseThresholdColor[$tone]};
+`;
+
+export const DefenseThresholdLabel = styled.span<{ $tone: DefenseThresholdTone }>`
+	font-size: ${({ $tone }) => defenseThresholdLabelSize[$tone]};
+	font-weight: ${theme.typography.fontWeight.semibold};
+	white-space: nowrap;
+`;
+
+export const DefenseThresholdValue = styled.span<{ $tone: DefenseThresholdTone }>`
+	font-size: ${({ $tone }) => defenseThresholdValueSize[$tone]};
+	font-weight: ${theme.typography.fontWeight.bold};
+	line-height: 1;
+	font-variant-numeric: tabular-nums;
+`;
+
+export const ReductionIndicators = styled.div`
+	display: grid;
+	grid-template-rows: repeat(3, auto);
+	align-content: center;
+	gap: ${theme.spacing[2]};
+
+	& > div {
+		display: block;
+	}
+
+	& > div > div:first-child {
+		display: block;
+	}
+
+	${media.mobile} {
+		grid-template-columns: repeat(3, minmax(0, 1fr));
+		grid-template-rows: none;
+	}
+`;
+
+export const ReductionCard = styled.div`
+	display: grid;
+	align-content: start;
+	gap: ${theme.spacing[3]};
+	min-width: 116px;
+	padding: ${theme.spacing[3]};
+	background: ${theme.colors.bg.primary};
+	border: 1px solid ${theme.colors.border.default};
+	border-top: 3px solid ${theme.colors.text.muted};
+	border-radius: ${theme.borderRadius.lg};
+
+	${media.mobile} {
+		min-width: 0;
+	}
+`;
+
+export const ReductionTitle = styled.h3`
+	margin: 0;
+	color: ${theme.colors.text.primary};
+	font-size: ${theme.typography.fontSize.sm};
+	font-weight: ${theme.typography.fontWeight.bold};
+	line-height: ${theme.typography.lineHeight.tight};
+`;
+
+export const ReductionBadge = styled.div`
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: ${theme.spacing[2]};
+	min-height: 32px;
+	color: ${theme.colors.text.primary};
+	font-size: ${theme.typography.fontSize.sm};
+	font-weight: ${theme.typography.fontWeight.bold};
+`;
+
+export const ReductionSquare = styled.span<{ $active: boolean }>`
+	width: 18px;
+	height: 18px;
+	flex: 0 0 18px;
+	background: ${({ $active }) =>
+		$active ? theme.colors.accent.success : theme.colors.bg.secondary};
+	border: 2px solid
+		${({ $active }) => ($active ? theme.colors.accent.success : theme.colors.text.secondary)};
+	border-radius: ${theme.borderRadius.sm};
+	box-shadow: ${({ $active }) =>
+		$active
+			? `0 0 0 2px color-mix(in srgb, ${theme.colors.accent.success} 20%, transparent)`
+			: 'none'};
+`;

--- a/src/routes/character-sheet/alternative/AlternativeCombatResourceSection.test.tsx
+++ b/src/routes/character-sheet/alternative/AlternativeCombatResourceSection.test.tsx
@@ -1,0 +1,55 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import AlternativeCombatResourceSection, {
+	getDamageReductionState
+} from './AlternativeCombatResourceSection';
+
+afterEach(cleanup);
+
+describe('AlternativeCombatResourceSection', () => {
+	it('maps categorical damage reductions from calculated resistances', () => {
+		expect(
+			getDamageReductionState(0, [
+				{ type: 'elemental', value: 'true' },
+				{ type: 'mystical', value: 'true' }
+			])
+		).toEqual({ pdr: false, edr: true, mdr: true });
+
+		expect(getDamageReductionState(2, [])).toEqual({
+			pdr: true,
+			edr: false,
+			mdr: false
+		});
+	});
+
+	it('renders combat values and rolls actionable metrics', () => {
+		const onRoll = vi.fn();
+		render(
+			<AlternativeCombatResourceSection
+				attackBonus={5}
+				saveDC={15}
+				initiative={4}
+				moveSpeed={5}
+				jumpDistance={3}
+				precisionDefense={12}
+				areaDefense={11}
+				physicalDamageReduction={0}
+				resistances={[{ type: 'elemental', value: 'true' }]}
+				onRoll={onRoll}
+			/>
+		);
+
+		expect(screen.getByRole('group', { name: 'Defense thresholds' })).toBeTruthy();
+		expect(screen.getByLabelText('Precision Defense 12')).toBeTruthy();
+		expect(screen.getByLabelText('Area Defense 11')).toBeTruthy();
+		expect(screen.getByLabelText('PDR inactive')).toBeTruthy();
+		expect(screen.getByLabelText('EDR active')).toBeTruthy();
+		expect(screen.getByLabelText('MDR inactive')).toBeTruthy();
+
+		fireEvent.click(screen.getByRole('button', { name: 'Roll Attack +5' }));
+		expect(onRoll).toHaveBeenLastCalledWith('Attack', 5, 'attack');
+
+		fireEvent.click(screen.getByRole('button', { name: 'Roll Initiative +4' }));
+		expect(onRoll).toHaveBeenLastCalledWith('Initiative', 4, 'physical-check');
+	});
+});

--- a/src/routes/character-sheet/alternative/AlternativeCombatResourceSection.tsx
+++ b/src/routes/character-sheet/alternative/AlternativeCombatResourceSection.tsx
@@ -1,0 +1,226 @@
+import type { Resistance } from '../../../lib/services/calculatorModules/abilityCollection';
+import Tooltip from '../components/Tooltip';
+import { theme } from '../styles/theme';
+import type { RollActionType } from './AlternativeMasterySection';
+import {
+	ActionCopy,
+	ActionEyebrow,
+	ActionLabel,
+	ActionPanel,
+	ActionValue,
+	AttackButton,
+	CombatResourceSection,
+	DefenseAbbreviation,
+	DefenseCard,
+	DefenseCards,
+	DefensePanel,
+	DefenseThreshold,
+	DefenseThresholdLabel,
+	DefenseThresholds,
+	DefenseThresholdValue,
+	DefenseTitle,
+	MetricLabel,
+	MetricValue,
+	ReductionBadge,
+	ReductionCard,
+	ReductionIndicators,
+	ReductionSquare,
+	ReductionTitle,
+	TacticalButton,
+	TacticalGrid,
+	TacticalMetric
+} from './AlternativeCombatResourceSection.styles';
+
+interface AlternativeCombatResourceSectionProps {
+	attackBonus: number;
+	saveDC: number;
+	initiative: number;
+	moveSpeed: number;
+	jumpDistance: number;
+	precisionDefense: number;
+	areaDefense: number;
+	physicalDamageReduction: number;
+	resistances: Array<Pick<Resistance, 'type' | 'value'>>;
+	onRoll: (label: string, bonus: number, actionType: RollActionType) => void;
+}
+
+interface DamageReductionState {
+	pdr: boolean;
+	edr: boolean;
+	mdr: boolean;
+}
+
+const DAMAGE_REDUCTION_TOOLTIPS = {
+	pdr: 'Physical Damage Reduction: Bludgeoning, Piercing, and Slashing.',
+	edr: 'Elemental Damage Reduction: Cold, Corrosion, Fire, Lightning, and Poison.',
+	mdr: 'Mystical Damage Reduction: Radiant, Psychic, and Umbral.'
+} as const;
+
+function formatSigned(value: number): string {
+	return `${value >= 0 ? '+' : ''}${value}`;
+}
+
+export function getDamageReductionState(
+	physicalDamageReduction: number,
+	resistances: Array<Pick<Resistance, 'type' | 'value'>>
+): DamageReductionState {
+	const hasCategoryReduction = (...categories: string[]) =>
+		resistances.some(
+			(resistance) =>
+				categories.includes(resistance.type.toLowerCase()) &&
+				String(resistance.value).toLowerCase() === 'true'
+		);
+
+	return {
+		pdr: physicalDamageReduction > 0 || hasCategoryReduction('physical'),
+		edr: hasCategoryReduction('elemental'),
+		mdr: hasCategoryReduction('mystical', 'mental')
+	};
+}
+
+function ReductionIndicator({
+	label,
+	active,
+	tooltip
+}: {
+	label: string;
+	active: boolean;
+	tooltip: string;
+}) {
+	return (
+		<Tooltip content={tooltip} position="top" maxWidth="320px">
+			<ReductionBadge aria-label={`${label} ${active ? 'active' : 'inactive'}`}>
+				{label}
+				<ReductionSquare $active={active} aria-hidden="true" />
+			</ReductionBadge>
+		</Tooltip>
+	);
+}
+
+function DefenseDisplay({
+	label,
+	abbreviation,
+	value,
+	color
+}: {
+	label: string;
+	abbreviation: string;
+	value: number;
+	color: string;
+}) {
+	return (
+		<DefenseCard $color={color} aria-label={`${label} ${value}`}>
+			<DefenseTitle $color={color}>
+				{label}
+				<DefenseAbbreviation $color={color}>{abbreviation}</DefenseAbbreviation>
+			</DefenseTitle>
+			<DefenseThresholds>
+				<DefenseThreshold $tone="hit">
+					<DefenseThresholdLabel $tone="hit">Hit</DefenseThresholdLabel>
+					<DefenseThresholdValue $tone="hit">{value}</DefenseThresholdValue>
+				</DefenseThreshold>
+				<DefenseThreshold $tone="heavy">
+					<DefenseThresholdLabel $tone="heavy">Heavy hit</DefenseThresholdLabel>
+					<DefenseThresholdValue $tone="heavy">{value + 5}</DefenseThresholdValue>
+				</DefenseThreshold>
+				<DefenseThreshold $tone="brutal">
+					<DefenseThresholdLabel $tone="brutal">Brutal hit</DefenseThresholdLabel>
+					<DefenseThresholdValue $tone="brutal">{value + 10}</DefenseThresholdValue>
+				</DefenseThreshold>
+			</DefenseThresholds>
+		</DefenseCard>
+	);
+}
+
+export default function AlternativeCombatResourceSection({
+	attackBonus,
+	saveDC,
+	initiative,
+	moveSpeed,
+	jumpDistance,
+	precisionDefense,
+	areaDefense,
+	physicalDamageReduction,
+	resistances,
+	onRoll
+}: AlternativeCombatResourceSectionProps) {
+	const damageReduction = getDamageReductionState(physicalDamageReduction, resistances);
+
+	return (
+		<CombatResourceSection aria-label="Alternative combat">
+			<ActionPanel>
+				<AttackButton
+					type="button"
+					aria-label={`Roll Attack ${formatSigned(attackBonus)}`}
+					onClick={() => onRoll('Attack', attackBonus, 'attack')}
+				>
+					<ActionCopy>
+						<ActionEyebrow>Primary roll</ActionEyebrow>
+						<ActionLabel>Attack</ActionLabel>
+					</ActionCopy>
+					<ActionValue>{formatSigned(attackBonus)}</ActionValue>
+				</AttackButton>
+				<TacticalGrid>
+					<TacticalMetric>
+						<MetricLabel>Save DC</MetricLabel>
+						<MetricValue>{saveDC}</MetricValue>
+					</TacticalMetric>
+					<TacticalButton
+						type="button"
+						aria-label={`Roll Initiative ${formatSigned(initiative)}`}
+						onClick={() => onRoll('Initiative', initiative, 'physical-check')}
+					>
+						<MetricLabel>Initiative</MetricLabel>
+						<MetricValue $actionable>{formatSigned(initiative)}</MetricValue>
+					</TacticalButton>
+					<TacticalMetric>
+						<MetricLabel>Move</MetricLabel>
+						<MetricValue>{moveSpeed}</MetricValue>
+					</TacticalMetric>
+					<TacticalMetric>
+						<MetricLabel>Jump</MetricLabel>
+						<MetricValue>{jumpDistance}</MetricValue>
+					</TacticalMetric>
+				</TacticalGrid>
+			</ActionPanel>
+
+			<DefensePanel role="group" aria-label="Defense thresholds">
+				<DefenseCards>
+					<DefenseDisplay
+						label="Precision Defense"
+						abbreviation="PD"
+						value={precisionDefense}
+						color={theme.colors.accent.secondary}
+					/>
+					<DefenseDisplay
+						label="Area Defense"
+						abbreviation="AD"
+						value={areaDefense}
+						color={theme.colors.accent.secondary}
+					/>
+				</DefenseCards>
+
+				<ReductionCard>
+					<ReductionTitle>Damage Reduction</ReductionTitle>
+					<ReductionIndicators aria-label="Damage reduction">
+						<ReductionIndicator
+							label="PDR"
+							active={damageReduction.pdr}
+							tooltip={DAMAGE_REDUCTION_TOOLTIPS.pdr}
+						/>
+						<ReductionIndicator
+							label="EDR"
+							active={damageReduction.edr}
+							tooltip={DAMAGE_REDUCTION_TOOLTIPS.edr}
+						/>
+						<ReductionIndicator
+							label="MDR"
+							active={damageReduction.mdr}
+							tooltip={DAMAGE_REDUCTION_TOOLTIPS.mdr}
+						/>
+					</ReductionIndicators>
+				</ReductionCard>
+			</DefensePanel>
+		</CombatResourceSection>
+	);
+}

--- a/src/routes/character-sheet/alternative/AlternativeMasterySection.styles.ts
+++ b/src/routes/character-sheet/alternative/AlternativeMasterySection.styles.ts
@@ -1,0 +1,191 @@
+import styled from 'styled-components';
+import { media, theme } from '../styles/theme';
+
+export const MasterySection = styled.section`
+	display: grid;
+	grid-template-columns: repeat(5, minmax(0, 1fr));
+	align-items: stretch;
+	gap: ${theme.spacing[3]};
+	padding: ${theme.spacing[6]};
+	background: ${theme.colors.bg.elevated};
+	border: 1px solid ${theme.colors.border.default};
+	border-radius: ${theme.borderRadius.xl};
+	box-shadow: ${theme.shadows.lg};
+
+	${media.tabletDown} {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+
+	${media.mobile} {
+		grid-template-columns: 1fr;
+		padding: ${theme.spacing[4]};
+	}
+`;
+
+export const MasterySidebar = styled.div`
+	display: grid;
+	grid-template-rows: 1fr auto;
+	gap: ${theme.spacing[3]};
+	min-width: 0;
+
+	${media.tabletDown} {
+		grid-column: 1 / -1;
+		grid-template-rows: auto auto;
+	}
+`;
+
+export const MasteryCard = styled.div`
+	display: flex;
+	flex-direction: column;
+	min-width: 0;
+	padding: ${theme.spacing[4]};
+	background: ${theme.colors.bg.secondary};
+	border: 1px solid transparent;
+	border-radius: ${theme.borderRadius.lg};
+	box-shadow: ${theme.shadows.md};
+`;
+
+export const CombatMasteryCard = styled(MasteryCard)`
+	align-items: center;
+	justify-content: center;
+	padding-block: ${theme.spacing[3]};
+	border-top: 3px solid color-mix(in srgb, ${theme.colors.accent.secondary} 70%, white 30%);
+`;
+
+export const PrimeCard = styled(MasteryCard)`
+	--mastery-dot-color: ${theme.colors.accent.secondary};
+
+	border-top: 3px solid ${theme.colors.accent.secondary};
+`;
+
+export const CardLabel = styled.div`
+	color: ${theme.colors.text.secondary};
+	font-size: ${theme.typography.fontSize.sm};
+	font-weight: ${theme.typography.fontWeight.semibold};
+	text-align: center;
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+`;
+
+export const CardValue = styled.div`
+	margin-top: ${theme.spacing[1]};
+	color: ${theme.colors.accent.secondary};
+	font-size: ${theme.typography.fontSize['2xl']};
+	font-weight: ${theme.typography.fontWeight.bold};
+	text-align: center;
+	font-variant-numeric: tabular-nums;
+`;
+
+export const AttributeCard = styled(MasteryCard)<{ $color: string }>`
+	--mastery-dot-color: ${({ $color }) => $color};
+
+	min-height: 300px;
+	border-top: 3px solid ${({ $color }) => $color};
+`;
+
+export const AttributeHeader = styled.div`
+	display: grid;
+	justify-items: center;
+	gap: ${theme.spacing[2]};
+	margin-bottom: ${theme.spacing[4]};
+`;
+
+export const AttributeName = styled.div<{ $color: string }>`
+	color: ${({ $color }) => $color};
+	font-size: ${theme.typography.fontSize.base};
+	font-weight: ${theme.typography.fontWeight.bold};
+	text-transform: capitalize;
+`;
+
+export const AttributeNumbers = styled.div`
+	display: flex;
+	align-items: baseline;
+	justify-content: center;
+	gap: ${theme.spacing[2]};
+	color: ${theme.colors.text.primary};
+	font-size: ${theme.typography.fontSize.xl};
+	font-weight: ${theme.typography.fontWeight.bold};
+	font-variant-numeric: tabular-nums;
+`;
+
+export const SaveButton = styled.button`
+	padding: ${theme.spacing[1]} ${theme.spacing[2]};
+	background: transparent;
+	border: 0;
+	border-radius: ${theme.borderRadius.sm};
+	color: ${theme.colors.text.secondary};
+	font: inherit;
+	font-size: ${theme.typography.fontSize.sm};
+	cursor: pointer;
+	transition: all ${theme.transitions.fast};
+
+	&:hover,
+	&:focus-visible {
+		background: ${theme.colors.bg.tertiary};
+		color: ${theme.colors.accent.primary};
+	}
+`;
+
+export const MasteryRows = styled.div`
+	display: grid;
+	gap: ${theme.spacing[1]};
+`;
+
+export const MasteryRow = styled.button`
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: ${theme.spacing[2]};
+	width: 100%;
+	min-height: 34px;
+	padding: ${theme.spacing[2]};
+	background: ${theme.colors.bg.primary};
+	border: 1px solid ${theme.colors.border.default};
+	border-radius: ${theme.borderRadius.md};
+	color: ${theme.colors.text.primary};
+	font: inherit;
+	text-align: left;
+	cursor: pointer;
+	transition:
+		background-color ${theme.transitions.fast},
+		border-color ${theme.transitions.fast};
+
+	&:hover,
+	&:focus-visible {
+		background: ${theme.colors.bg.tertiary};
+		border-color: ${theme.colors.accent.primary};
+	}
+`;
+
+export const MasteryName = styled.span`
+	min-width: 0;
+	overflow: hidden;
+	font-size: ${theme.typography.fontSize.sm};
+	font-weight: ${theme.typography.fontWeight.medium};
+	text-overflow: ellipsis;
+	white-space: nowrap;
+`;
+
+export const MasteryResult = styled.span`
+	display: flex;
+	flex: 0 0 auto;
+	align-items: center;
+	gap: ${theme.spacing[2]};
+`;
+
+export const MasteryBonus = styled.span`
+	min-width: 2.5ch;
+	color: ${theme.colors.text.primary};
+	font-size: ${theme.typography.fontSize.sm};
+	font-weight: ${theme.typography.fontWeight.bold};
+	text-align: right;
+	font-variant-numeric: tabular-nums;
+`;
+
+export const TradeRows = styled.div`
+	display: grid;
+	gap: ${theme.spacing[1]};
+	margin-top: ${theme.spacing[2]};
+	padding-top: ${theme.spacing[2]};
+	border-top: 1px solid ${theme.colors.border.default};
+`;

--- a/src/routes/character-sheet/alternative/AlternativeMasterySection.test.tsx
+++ b/src/routes/character-sheet/alternative/AlternativeMasterySection.test.tsx
@@ -1,0 +1,79 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { SavedCharacter } from '../../../lib/types/dataContracts';
+import AlternativeMasterySection from './AlternativeMasterySection';
+
+vi.mock('react-i18next', () => ({
+	useTranslation: () => ({
+		t: (key: string) => {
+			const labels: Record<string, string> = {
+				'characterSheet.attrCombatMastery': 'Combat Mastery',
+				'characterSheet.attrPrime': 'Prime',
+				'characterSheet.attrMight': 'MIGHT',
+				'characterSheet.attrAgility': 'AGILITY',
+				'characterSheet.attrCharisma': 'CHARISMA',
+				'characterSheet.attrIntelligence': 'INTELLIGENCE',
+				'characterSheet.attrSave': 'SAVE'
+			};
+			return labels[key] ?? key;
+		}
+	})
+}));
+
+vi.mock('../hooks/CharacterSheetProvider', () => {
+	const character = {
+		id: 'test-character',
+		finalMight: 3,
+		finalAgility: 2,
+		finalCharisma: 1,
+		finalIntelligence: 0,
+		finalSaveMight: 5,
+		finalSaveAgility: 4,
+		finalSaveCharisma: 3,
+		finalSaveIntelligence: 2,
+		finalPrimeModifierValue: 3,
+		finalCombatMastery: 2,
+		skillsData: {
+			awareness: 1,
+			athletics: 1
+		}
+	} as SavedCharacter;
+
+	return {
+		useCharacterSheet: () => ({ state: { character } }),
+		useCharacterCalculatedData: () => null,
+		useCharacterTrades: () => [
+			{
+				id: 'blacksmithing',
+				name: 'Blacksmithing',
+				proficiency: 1,
+				primaryAttribute: 'might',
+				bonus: 5,
+				bonuses: [{ attribute: 'might', total: 5 }]
+			}
+		]
+	};
+});
+
+afterEach(cleanup);
+
+describe('AlternativeMasterySection', () => {
+	it('groups real skills and trades with their roll actions', () => {
+		const onRoll = vi.fn();
+		render(<AlternativeMasterySection onRoll={onRoll} />);
+		const sectionText = screen.getByLabelText('Attributes, skills, and trades').textContent ?? '';
+
+		expect(screen.getByText('Combat Mastery')).toBeTruthy();
+		expect(screen.getByText('Prime')).toBeTruthy();
+		expect(sectionText.indexOf('Prime')).toBeLessThan(sectionText.indexOf('Combat Mastery'));
+		expect(screen.getByRole('button', { name: 'Roll Awareness +5' })).toBeTruthy();
+		expect(screen.getByRole('button', { name: 'Roll Athletics +5' })).toBeTruthy();
+		expect(screen.getByRole('button', { name: 'Roll Blacksmithing +5' })).toBeTruthy();
+
+		fireEvent.click(screen.getByRole('button', { name: 'Roll MIGHT save +5' }));
+		expect(onRoll).toHaveBeenCalledWith('MIGHT SAVE', 5, 'physical-save');
+
+		fireEvent.click(screen.getByRole('button', { name: 'Roll Blacksmithing +5' }));
+		expect(onRoll).toHaveBeenLastCalledWith('Blacksmithing', 5, 'physical-check');
+	});
+});

--- a/src/routes/character-sheet/alternative/AlternativeMasterySection.tsx
+++ b/src/routes/character-sheet/alternative/AlternativeMasterySection.tsx
@@ -1,0 +1,242 @@
+import { useTranslation } from 'react-i18next';
+import { skillsData } from '../../../lib/rulesdata/skills';
+import { StyledDot, StyledProficiencyDots } from '../styles/Skills';
+import {
+	useCharacterCalculatedData,
+	useCharacterSheet,
+	useCharacterTrades
+} from '../hooks/CharacterSheetProvider';
+import {
+	AttributeCard,
+	AttributeHeader,
+	AttributeName,
+	AttributeNumbers,
+	CardLabel,
+	CardValue,
+	CombatMasteryCard,
+	MasteryBonus,
+	MasteryName,
+	MasteryResult,
+	MasteryRow,
+	MasteryRows,
+	MasterySection,
+	MasterySidebar,
+	PrimeCard,
+	SaveButton,
+	TradeRows
+} from './AlternativeMasterySection.styles';
+import { theme } from '../styles/theme';
+
+export type RollActionType =
+	| 'attack'
+	| 'physical-check'
+	| 'mental-check'
+	| 'physical-save'
+	| 'mental-save'
+	| 'agility-save';
+
+type AttributeKey = 'might' | 'agility' | 'charisma' | 'intelligence';
+
+interface AlternativeMasterySectionProps {
+	onRoll: (label: string, bonus: number, actionType: RollActionType) => void;
+}
+
+interface MasteryItem {
+	id: string;
+	name: string;
+	proficiency: number;
+	bonus: number;
+}
+
+const ATTRIBUTE_KEYS: AttributeKey[] = ['might', 'agility', 'charisma', 'intelligence'];
+
+function formatSigned(value: number): string {
+	return `${value >= 0 ? '+' : ''}${value}`;
+}
+
+function checkActionType(attribute: AttributeKey): RollActionType {
+	return attribute === 'might' || attribute === 'agility' ? 'physical-check' : 'mental-check';
+}
+
+function saveActionType(attribute: AttributeKey): RollActionType {
+	if (attribute === 'agility') return 'agility-save';
+	return attribute === 'might' ? 'physical-save' : 'mental-save';
+}
+
+function MasteryDots({ proficiency }: { proficiency: number }) {
+	return (
+		<StyledProficiencyDots aria-label={`Mastery ${proficiency} of 5`}>
+			{[1, 2, 3, 4, 5].map((level) => (
+				<StyledDot key={level} $filled={level <= proficiency} />
+			))}
+		</StyledProficiencyDots>
+	);
+}
+
+function ActionRow({ item, onClick }: { item: MasteryItem; onClick: () => void }) {
+	return (
+		<MasteryRow
+			type="button"
+			onClick={onClick}
+			aria-label={`Roll ${item.name} ${formatSigned(item.bonus)}`}
+		>
+			<MasteryName title={item.name}>{item.name}</MasteryName>
+			<MasteryResult>
+				<MasteryBonus>{formatSigned(item.bonus)}</MasteryBonus>
+				<MasteryDots proficiency={item.proficiency} />
+			</MasteryResult>
+		</MasteryRow>
+	);
+}
+
+export default function AlternativeMasterySection({ onRoll }: AlternativeMasterySectionProps) {
+	const { t } = useTranslation();
+	const { state } = useCharacterSheet();
+	const calculatedData = useCharacterCalculatedData();
+	const trades = useCharacterTrades();
+	const character = state.character;
+
+	if (!character) return null;
+
+	const stats = calculatedData?.stats;
+	const attributeValues: Record<AttributeKey, number> = {
+		might: stats?.finalMight ?? character.finalMight ?? 0,
+		agility: stats?.finalAgility ?? character.finalAgility ?? 0,
+		charisma: stats?.finalCharisma ?? character.finalCharisma ?? 0,
+		intelligence: stats?.finalIntelligence ?? character.finalIntelligence ?? 0
+	};
+	const saveValues: Record<AttributeKey, number> = {
+		might: stats?.finalSaveMight ?? character.finalSaveMight ?? 0,
+		agility: stats?.finalSaveAgility ?? character.finalSaveAgility ?? 0,
+		charisma: stats?.finalSaveCharisma ?? character.finalSaveCharisma ?? 0,
+		intelligence: stats?.finalSaveIntelligence ?? character.finalSaveIntelligence ?? 0
+	};
+	const primeValue = stats?.finalPrimeModifierValue ?? character.finalPrimeModifierValue ?? 0;
+	const combatMastery = stats?.finalCombatMastery ?? character.finalCombatMastery ?? 0;
+	const masteryBySkill = character.skillsData ?? {};
+
+	const skillGroups = ATTRIBUTE_KEYS.reduce<Record<AttributeKey, MasteryItem[]>>(
+		(groups, attribute) => {
+			groups[attribute] = skillsData
+				.filter((skill) => skill.attributeAssociation === attribute)
+				.map((skill) => {
+					const proficiency = masteryBySkill[skill.id] ?? 0;
+					return {
+						id: skill.id,
+						name: skill.name,
+						proficiency,
+						bonus: attributeValues[attribute] + proficiency * 2
+					};
+				});
+			return groups;
+		},
+		{ might: [], agility: [], charisma: [], intelligence: [] }
+	);
+
+	const tradeGroups = ATTRIBUTE_KEYS.reduce<Record<AttributeKey, MasteryItem[]>>(
+		(groups, attribute) => {
+			groups[attribute] = [];
+			return groups;
+		},
+		{ might: [], agility: [], charisma: [], intelligence: [] }
+	);
+	for (const trade of trades) {
+		const governingAttribute = trade.bonuses?.[0]?.attribute ?? trade.primaryAttribute;
+		tradeGroups[governingAttribute].push({
+			id: trade.id,
+			name: trade.name,
+			proficiency: trade.proficiency,
+			bonus: trade.bonus ?? attributeValues[governingAttribute] + trade.proficiency * 2
+		});
+	}
+
+	const awarenessDefinition = skillsData.find((skill) => skill.id === 'awareness');
+	const awarenessProficiency = masteryBySkill.awareness ?? 0;
+	const awareness: MasteryItem = {
+		id: 'awareness',
+		name: awarenessDefinition?.name ?? 'Awareness',
+		proficiency: awarenessProficiency,
+		bonus: primeValue + awarenessProficiency * 2
+	};
+
+	const attributeLabels: Record<AttributeKey, string> = {
+		might: t('characterSheet.attrMight'),
+		agility: t('characterSheet.attrAgility'),
+		charisma: t('characterSheet.attrCharisma'),
+		intelligence: t('characterSheet.attrIntelligence')
+	};
+
+	return (
+		<MasterySection aria-label="Attributes, skills, and trades">
+			<MasterySidebar>
+				<PrimeCard>
+					<AttributeHeader>
+						<AttributeName $color={theme.colors.accent.secondary}>
+							{t('characterSheet.attrPrime')}
+						</AttributeName>
+						<AttributeNumbers>{formatSigned(primeValue)}</AttributeNumbers>
+					</AttributeHeader>
+					<MasteryRows>
+						<ActionRow
+							item={awareness}
+							onClick={() => onRoll(awareness.name, awareness.bonus, 'mental-check')}
+						/>
+					</MasteryRows>
+				</PrimeCard>
+				<CombatMasteryCard>
+					<CardLabel>{t('characterSheet.attrCombatMastery')}</CardLabel>
+					<CardValue>{formatSigned(combatMastery)}</CardValue>
+				</CombatMasteryCard>
+			</MasterySidebar>
+
+			{ATTRIBUTE_KEYS.map((attribute) => (
+				<AttributeCard key={attribute} $color={theme.colors.attribute[attribute]}>
+					<AttributeHeader>
+						<AttributeName $color={theme.colors.attribute[attribute]}>
+							{attributeLabels[attribute].toLowerCase()}
+						</AttributeName>
+						<AttributeNumbers>
+							{formatSigned(attributeValues[attribute])}
+							<SaveButton
+								type="button"
+								aria-label={`Roll ${attributeLabels[attribute]} save ${formatSigned(
+									saveValues[attribute]
+								)}`}
+								onClick={() =>
+									onRoll(
+										`${attributeLabels[attribute]} ${t('characterSheet.attrSave')}`,
+										saveValues[attribute],
+										saveActionType(attribute)
+									)
+								}
+							>
+								({formatSigned(saveValues[attribute])} {t('characterSheet.attrSave').toLowerCase()})
+							</SaveButton>
+						</AttributeNumbers>
+					</AttributeHeader>
+
+					<MasteryRows>
+						{skillGroups[attribute].map((skill) => (
+							<ActionRow
+								key={skill.id}
+								item={skill}
+								onClick={() => onRoll(skill.name, skill.bonus, checkActionType(attribute))}
+							/>
+						))}
+						{tradeGroups[attribute].length > 0 && (
+							<TradeRows>
+								{tradeGroups[attribute].map((trade) => (
+									<ActionRow
+										key={trade.id}
+										item={trade}
+										onClick={() => onRoll(trade.name, trade.bonus, checkActionType(attribute))}
+									/>
+								))}
+							</TradeRows>
+						)}
+					</MasteryRows>
+				</AttributeCard>
+			))}
+		</MasterySection>
+	);
+}

--- a/src/routes/character-sheet/alternative/AlternativeTabbedContent.styles.ts
+++ b/src/routes/character-sheet/alternative/AlternativeTabbedContent.styles.ts
@@ -1,0 +1,104 @@
+import styled from 'styled-components';
+import { media, theme } from '../styles/theme';
+
+export const TabbedContent = styled.section`
+	--delete-button-hover-transform: none;
+	--delete-button-transition: none;
+
+	overflow: hidden;
+	background: ${theme.colors.bg.elevated};
+	border: 1px solid ${theme.colors.border.default};
+	border-radius: ${theme.borderRadius.xl};
+	box-shadow: ${theme.shadows.lg};
+`;
+
+export const TabList = styled.div`
+	display: flex;
+	overflow-x: auto;
+	background: ${theme.colors.bg.secondary};
+	border-bottom: 1px solid ${theme.colors.border.default};
+	scrollbar-width: thin;
+	scrollbar-color: ${theme.colors.accent.primary} transparent;
+
+	&::-webkit-scrollbar {
+		height: 4px;
+	}
+
+	&::-webkit-scrollbar-thumb {
+		background: ${theme.colors.accent.primary};
+		border-radius: ${theme.borderRadius.full};
+	}
+`;
+
+export const TabButton = styled.button<{ $active: boolean }>`
+	position: relative;
+	display: inline-flex;
+	flex: 1 0 auto;
+	align-items: center;
+	justify-content: center;
+	gap: ${theme.spacing[2]};
+	min-height: 52px;
+	padding: ${theme.spacing[3]} ${theme.spacing[4]};
+	background: ${({ $active }) => ($active ? theme.colors.crystal.primaryAlpha10 : 'transparent')};
+	border: 0;
+	border-right: 1px solid ${theme.colors.border.default};
+	color: ${({ $active }) => ($active ? theme.colors.accent.primary : theme.colors.text.primary)};
+	font: inherit;
+	font-size: ${theme.typography.fontSize.base};
+	font-weight: ${theme.typography.fontWeight.semibold};
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+	white-space: nowrap;
+	cursor: pointer;
+	transition:
+		background ${theme.transitions.fast},
+		color ${theme.transitions.fast},
+		box-shadow ${theme.transitions.fast};
+	box-shadow: ${({ $active }) =>
+		$active ? `inset 0 0 0 1px ${theme.colors.crystal.primaryAlpha30}` : 'none'};
+
+	&:last-child {
+		border-right: 0;
+	}
+
+	&::after {
+		content: '';
+		position: absolute;
+		inset: 0 0 auto;
+		height: 3px;
+		background: ${({ $active }) => ($active ? theme.colors.accent.primary : 'transparent')};
+	}
+
+	&:hover,
+	&:focus-visible {
+		background: ${theme.colors.bg.tertiary};
+		color: ${theme.colors.text.primary};
+	}
+
+	${media.tabletDown} {
+		flex: 0 0 auto;
+	}
+`;
+
+export const TabBadge = styled.span`
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	min-width: 1.25rem;
+	height: 1.25rem;
+	padding: 0 ${theme.spacing[1]};
+	background: ${theme.colors.accent.danger};
+	border-radius: ${theme.borderRadius.full};
+	color: ${theme.colors.text.inverse};
+	font-size: ${theme.typography.fontSize.xs};
+	font-weight: ${theme.typography.fontWeight.bold};
+`;
+
+export const TabPanel = styled.div`
+	padding: ${theme.spacing[6]};
+	overflow-x: hidden;
+
+	${media.mobile} {
+		padding: ${theme.spacing[4]};
+	}
+`;

--- a/src/routes/character-sheet/alternative/AlternativeTabbedContent.tsx
+++ b/src/routes/character-sheet/alternative/AlternativeTabbedContent.tsx
@@ -1,0 +1,176 @@
+import { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { FeatureData, InventoryItemData } from '../../../types';
+import type { InventoryItem, Weapon } from '../../../lib/rulesdata/inventoryItems';
+import ActiveConditionSummary from '../components/ActiveConditionSummary';
+import ActiveConditionsTracker from '../components/ActiveConditionsTracker';
+import Attacks from '../components/Attacks';
+import ComplexFeatureHost from '../components/ComplexFeatureHost';
+import EffectsRulesNotes from '../components/EffectsRulesNotes';
+import FeaturePopup from '../components/FeaturePopup';
+import Features from '../components/Features';
+import Inventory from '../components/Inventory';
+import InventoryPopup from '../components/InventoryPopup';
+import Maneuvers from '../components/Maneuvers';
+import PlayerNotes from '../components/PlayerNotes';
+import Spells from '../components/Spells';
+import WeaponPopup from '../components/WeaponPopup';
+import { useCharacterConditions, useCharacterSheet } from '../hooks/CharacterSheetProvider';
+import {
+	TabBadge,
+	TabButton,
+	TabbedContent,
+	TabList,
+	TabPanel
+} from './AlternativeTabbedContent.styles';
+
+type TabId = 'attacks' | 'spells' | 'inventory' | 'maneuvers' | 'features' | 'conditions' | 'notes';
+
+export default function AlternativeTabbedContent() {
+	const { t } = useTranslation();
+	const {
+		state,
+		readOnly,
+		handleSpellCast,
+		handleManeuverUse,
+		toggleActiveCondition,
+		setActiveConditionStacks,
+		updateInventory
+	} = useCharacterSheet();
+	const conditionStatuses = useCharacterConditions();
+	const [activeTab, setActiveTab] = useState<TabId>('attacks');
+	const [selectedFeature, setSelectedFeature] = useState<FeatureData | null>(null);
+	const [selectedWeapon, setSelectedWeapon] = useState<Weapon | null>(null);
+	const [selectedInventoryItem, setSelectedInventoryItem] = useState<{
+		inventoryData: InventoryItemData;
+		item: InventoryItem | null;
+	} | null>(null);
+
+	const activeConditions = state.character?.characterState?.activeConditions ?? [];
+	const activeConditionCount = useMemo(
+		() => conditionStatuses.filter((status) => status.interactions?.length).length,
+		[conditionStatuses]
+	);
+	const tabs: Array<{ id: TabId; label: string; badge?: number }> = [
+		{ id: 'attacks', label: t('characterSheet.tabAttacks') },
+		{ id: 'spells', label: t('characterSheet.tabSpells') },
+		{ id: 'inventory', label: t('characterSheet.tabInventory') },
+		{ id: 'maneuvers', label: t('characterSheet.tabManeuvers') },
+		{ id: 'features', label: t('characterSheet.tabFeatures') },
+		{
+			id: 'conditions',
+			label: t('characterSheet.tabConditions'),
+			badge: activeConditionCount
+		},
+		{ id: 'notes', label: t('characterSheet.tabNotes') }
+	];
+
+	const updateCustomItem = (
+		itemId: string,
+		updates: Partial<Pick<InventoryItemData, 'description' | 'cost'>>
+	) => {
+		const items = state.character?.characterState?.inventory?.items ?? [];
+		updateInventory(items.map((item) => (item.id === itemId ? { ...item, ...updates } : item)));
+		setSelectedInventoryItem((current) => {
+			if (!current || current.inventoryData.id !== itemId) return current;
+			return {
+				...current,
+				inventoryData: { ...current.inventoryData, ...updates }
+			};
+		});
+	};
+
+	return (
+		<>
+			<TabbedContent aria-label="Character actions and details">
+				<TabList role="tablist" aria-label="Character content">
+					{tabs.map((tab) => (
+						<TabButton
+							key={tab.id}
+							type="button"
+							role="tab"
+							id={`alternative-tab-${tab.id}`}
+							aria-selected={activeTab === tab.id}
+							aria-controls={`alternative-panel-${tab.id}`}
+							tabIndex={activeTab === tab.id ? 0 : -1}
+							$active={activeTab === tab.id}
+							onClick={() => setActiveTab(tab.id)}
+						>
+							{tab.label}
+							{tab.badge ? <TabBadge>{tab.badge}</TabBadge> : null}
+						</TabButton>
+					))}
+				</TabList>
+
+				<TabPanel
+					role="tabpanel"
+					id={`alternative-panel-${activeTab}`}
+					aria-labelledby={`alternative-tab-${activeTab}`}
+				>
+					{activeTab === 'attacks' && (
+						<Attacks
+							showTitle={false}
+							explicitEditMode
+							onAttackClick={(_attack, weapon) => {
+								if (weapon) setSelectedWeapon(weapon);
+							}}
+						/>
+					)}
+					{activeTab === 'spells' && (
+						<Spells
+							showTitle={false}
+							onSpellClick={() => {}}
+							onSpellCast={handleSpellCast}
+							readOnly={readOnly}
+						/>
+					)}
+					{activeTab === 'inventory' && (
+						<Inventory
+							showTitle={false}
+							showInfoHeader={false}
+							explicitEditMode
+							onItemClick={(inventoryData, item) =>
+								setSelectedInventoryItem({ inventoryData, item })
+							}
+						/>
+					)}
+					{activeTab === 'maneuvers' && (
+						<Maneuvers
+							showTitle={false}
+							onManeuverClick={() => {}}
+							onManeuverUse={handleManeuverUse}
+							readOnly={readOnly}
+						/>
+					)}
+					{activeTab === 'features' && (
+						<>
+							<Features showTitle={false} onFeatureClick={setSelectedFeature} />
+							<EffectsRulesNotes />
+							<ComplexFeatureHost />
+						</>
+					)}
+					{activeTab === 'conditions' && (
+						<>
+							<ActiveConditionsTracker
+								showTitle={false}
+								activeConditions={activeConditions}
+								onToggleCondition={toggleActiveCondition}
+								onSetConditionStacks={setActiveConditionStacks}
+							/>
+							<ActiveConditionSummary activeConditions={activeConditions} />
+						</>
+					)}
+					{activeTab === 'notes' && <PlayerNotes showTitle={false} explicitEditMode />}
+				</TabPanel>
+			</TabbedContent>
+
+			<WeaponPopup weapon={selectedWeapon} onClose={() => setSelectedWeapon(null)} />
+			<InventoryPopup
+				selectedInventoryItem={selectedInventoryItem}
+				onClose={() => setSelectedInventoryItem(null)}
+				onUpdateCustomItem={updateCustomItem}
+			/>
+			<FeaturePopup feature={selectedFeature} onClose={() => setSelectedFeature(null)} />
+		</>
+	);
+}

--- a/src/routes/character-sheet/ancestryAttackTraits.test.ts
+++ b/src/routes/character-sheet/ancestryAttackTraits.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { getAncestryAttackTraits } from './ancestryAttackTraits';
+
+describe('getAncestryAttackTraits', () => {
+	it('applies Brutal Strikes only to martial melee attacks', () => {
+		const selectedTraitIds = ['orc_brutal_strikes'];
+
+		expect(
+			getAncestryAttackTraits({
+				selectedTraitIds,
+				isNaturalWeapon: false,
+				isMartialMelee: true,
+				isSupportedAttack: true
+			})
+		).toMatchObject({ brutalDamageBonus: 1 });
+
+		expect(
+			getAncestryAttackTraits({
+				selectedTraitIds,
+				isNaturalWeapon: false,
+				isMartialMelee: false,
+				isSupportedAttack: true
+			})
+		).toMatchObject({ brutalDamageBonus: 0 });
+	});
+
+	it('keeps Finishing Blow and Charge as scoped notes', () => {
+		const result = getAncestryAttackTraits({
+			selectedTraitIds: '["orc_finishing_blow","beastborn_charge"]',
+			isNaturalWeapon: false,
+			isMartialMelee: true,
+			isSupportedAttack: true
+		});
+
+		expect(result.brutalDamageBonus).toBe(0);
+		expect(result.notes).toEqual([
+			{ source: 'Finishing Blow', text: '+1 damage vs Well-Bloodied' },
+			{ source: 'Charge', text: '+1 damage after moving 2+ Spaces straight' }
+		]);
+	});
+
+	it('maps Natural Weapon properties and condition riders without applying their outcomes', () => {
+		const result = getAncestryAttackTraits({
+			selectedTraitIds: [
+				'beastborn_extended_natural_weapon',
+				'beastborn_long_limbed',
+				'beastborn_natural_projectile',
+				'beastborn_natural_weapon_style',
+				'beastborn_retractable_natural_weapon',
+				'beastborn_rend',
+				'beastborn_venomous_natural_weapon'
+			],
+			isNaturalWeapon: true,
+			isMartialMelee: true,
+			isSupportedAttack: true
+		});
+
+		expect(result.properties).toEqual([
+			'Reach +1 Space',
+			'Reach',
+			'Ranged 10 Spaces',
+			'Concealable'
+		]);
+		expect(result.notes).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ source: 'Natural Weapon Style' }),
+				expect.objectContaining({ source: 'Retractable' }),
+				expect.objectContaining({ source: 'Rend' }),
+				expect.objectContaining({ source: 'Venomous' })
+			])
+		);
+		expect(result.brutalDamageBonus).toBe(0);
+	});
+});

--- a/src/routes/character-sheet/ancestryAttackTraits.ts
+++ b/src/routes/character-sheet/ancestryAttackTraits.ts
@@ -1,0 +1,114 @@
+export interface AttackTraitNote {
+	source: string;
+	text: string;
+}
+
+interface AncestryAttackTraitsInput {
+	selectedTraitIds: unknown;
+	isNaturalWeapon: boolean;
+	isMartialMelee: boolean;
+	isSupportedAttack: boolean;
+}
+
+export interface AncestryAttackTraits {
+	brutalDamageBonus: number;
+	properties: string[];
+	notes: AttackTraitNote[];
+}
+
+function normalizeTraitIds(selectedTraitIds: unknown): Set<string> {
+	if (Array.isArray(selectedTraitIds)) {
+		return new Set(
+			selectedTraitIds.filter((traitId): traitId is string => typeof traitId === 'string')
+		);
+	}
+
+	if (typeof selectedTraitIds !== 'string') return new Set();
+
+	const parsed = parseJsonSafe<unknown>(selectedTraitIds);
+	return Array.isArray(parsed)
+		? new Set(parsed.filter((traitId): traitId is string => typeof traitId === 'string'))
+		: new Set();
+}
+
+export function getAncestryAttackTraits({
+	selectedTraitIds,
+	isNaturalWeapon,
+	isMartialMelee,
+	isSupportedAttack
+}: AncestryAttackTraitsInput): AncestryAttackTraits {
+	const selected = normalizeTraitIds(selectedTraitIds);
+	const properties: string[] = [];
+	const notes: AttackTraitNote[] = [];
+
+	if (isSupportedAttack && selected.has('orc_finishing_blow')) {
+		notes.push({
+			source: 'Finishing Blow',
+			text: '+1 damage vs Well-Bloodied'
+		});
+	}
+
+	if (isMartialMelee && selected.has('orc_brutal_strikes')) {
+		notes.push({
+			source: 'Brutal Strikes',
+			text: '+1 Brutal/Critical damage'
+		});
+	}
+
+	if (isMartialMelee && selected.has('beastborn_charge')) {
+		notes.push({
+			source: 'Charge',
+			text: '+1 damage after moving 2+ Spaces straight'
+		});
+	}
+
+	if (isMartialMelee && selected.has('beastborn_long_limbed')) {
+		properties.push('Reach +1 Space');
+	}
+
+	if (isNaturalWeapon) {
+		if (selected.has('beastborn_extended_natural_weapon')) {
+			properties.push('Reach');
+		}
+
+		if (selected.has('beastborn_natural_projectile')) {
+			properties.push('Ranged 10 Spaces');
+		}
+
+		if (selected.has('beastborn_retractable_natural_weapon')) {
+			properties.push('Concealable');
+			notes.push({
+				source: 'Retractable',
+				text: 'ADV on first Attack Check in Combat'
+			});
+		}
+
+		if (selected.has('beastborn_natural_weapon_style')) {
+			notes.push({
+				source: 'Natural Weapon Style',
+				text: 'Weapon Enhancement available; style choice not recorded'
+			});
+		}
+
+		if (selected.has('beastborn_rend')) {
+			notes.push({
+				source: 'Rend',
+				text: '1 AP; Physical Save failure → Bleeding'
+			});
+		}
+
+		if (selected.has('beastborn_venomous_natural_weapon')) {
+			notes.push({
+				source: 'Venomous',
+				text: '1 AP; Physical Save failure → Impaired (1 minute)'
+			});
+		}
+	}
+
+	return {
+		brutalDamageBonus: isMartialMelee && selected.has('orc_brutal_strikes') ? 1 : 0,
+		properties,
+		notes
+	};
+}
+import { parseJsonSafe } from '../../lib/utils/storageUtils';

--- a/src/routes/character-sheet/attackPresentation.test.ts
+++ b/src/routes/character-sheet/attackPresentation.test.ts
@@ -80,4 +80,14 @@ describe('getAttackPresentation', () => {
 			})
 		).toMatchObject({ conditionalDamageBonus: 0, baseDamage: '1 S' });
 	});
+
+	it('applies a brutal-only bonus without changing base or heavy damage', () => {
+		expect(
+			getAttackPresentation({
+				attack: attack('Longsword'),
+				weapon: meleeWeapon,
+				brutalDamageBonus: 1
+			})
+		).toMatchObject({ baseDamage: '1 S', heavyDamage: '2 S', brutalDamage: '4 S' });
+	});
 });

--- a/src/routes/character-sheet/attackPresentation.test.ts
+++ b/src/routes/character-sheet/attackPresentation.test.ts
@@ -56,6 +56,21 @@ describe('getAttackPresentation', () => {
 		).toMatchObject({ isSupportedAttack: true, baseDamage: '1 B', heavyDamage: '2 B' });
 	});
 
+	it('presents an unresolved Natural Weapon damage type across every hit tier', () => {
+		expect(
+			getAttackPresentation({
+				attack: attack('Unarmed Strike', '1 B/P/S'),
+				weapon: null
+			})
+		).toMatchObject({
+			isSupportedAttack: true,
+			baseDamage: '1 B/P/S',
+			heavyDamage: '2 B/P/S',
+			brutalDamage: '3 B/P/S',
+			damageType: 'bludgeoning/piercing/slashing'
+		});
+	});
+
 	it('does not apply melee effects when the condition is inactive', () => {
 		expect(
 			getAttackPresentation({

--- a/src/routes/character-sheet/attackPresentation.ts
+++ b/src/routes/character-sheet/attackPresentation.ts
@@ -8,6 +8,7 @@ interface AttackPresentationInput {
 	weapon: Weapon | null;
 	conditionalModifiers?: ConditionalModifier[];
 	activeConditions?: Iterable<string>;
+	brutalDamageBonus?: number;
 }
 
 export interface AttackPresentation {
@@ -30,7 +31,8 @@ export function getAttackPresentation({
 	attack,
 	weapon,
 	conditionalModifiers = [],
-	activeConditions = []
+	activeConditions = [],
+	brutalDamageBonus = 0
 }: AttackPresentationInput): AttackPresentation {
 	const active = new Set(activeConditions);
 	const normalizedName = (attack.weaponName || attack.name).trim().toLocaleLowerCase();
@@ -69,7 +71,7 @@ export function getAttackPresentation({
 		conditionalDamageBonus,
 		baseDamage,
 		heavyDamage: addDamage(heavyBase, conditionalDamageBonus),
-		brutalDamage: addDamage(brutalBase, conditionalDamageBonus),
+		brutalDamage: addDamage(brutalBase, conditionalDamageBonus + brutalDamageBonus),
 		damageType: parsed.typeDisplay,
 		note:
 			conditionalDamageBonus > 0

--- a/src/routes/character-sheet/components/ActiveConditionsTracker.tsx
+++ b/src/routes/character-sheet/components/ActiveConditionsTracker.tsx
@@ -23,6 +23,7 @@ interface ActiveConditionsTrackerProps {
 	onToggleCondition: (conditionId: string) => void;
 	onSetConditionStacks?: (conditionId: string, stacks: number) => void;
 	isMobile?: boolean;
+	showTitle?: boolean;
 }
 
 const Container = styled.section<{ $isMobile?: boolean }>`
@@ -266,7 +267,8 @@ export const ActiveConditionsTracker: React.FC<ActiveConditionsTrackerProps> = (
 	activeConditions,
 	onToggleCondition,
 	onSetConditionStacks,
-	isMobile = false
+	isMobile = false,
+	showTitle = true
 }) => {
 	const { t } = useTranslation();
 	const [searchTerm, setSearchTerm] = useState('');
@@ -345,7 +347,7 @@ export const ActiveConditionsTracker: React.FC<ActiveConditionsTrackerProps> = (
 	return (
 		<Container $isMobile={isMobile}>
 			<Header>
-				<Title>⚔️ {t('characterSheet.conditionsTitle')}</Title>
+				{showTitle && <Title>⚔️ {t('characterSheet.conditionsTitle')}</Title>}
 				<ActiveCount>
 					{t('characterSheet.conditionsActive', { count: activeConditions.length })}
 				</ActiveCount>

--- a/src/routes/character-sheet/components/Attacks.test.tsx
+++ b/src/routes/character-sheet/components/Attacks.test.tsx
@@ -16,7 +16,16 @@ vi.mock('../hooks/CharacterSheetProvider', () => ({
 		updateAttack: vi.fn(),
 		state: {
 			character: {
-				selectedTraitIds: ['beastborn_natural_weapon'],
+				selectedTraitIds: [
+					'beastborn_natural_weapon',
+					'beastborn_extended_natural_weapon',
+					'beastborn_long_limbed',
+					'beastborn_natural_projectile',
+					'beastborn_natural_weapon_style',
+					'beastborn_retractable_natural_weapon',
+					'beastborn_rend',
+					'beastborn_venomous_natural_weapon'
+				],
 				characterState: { ui: { activeConditions: {} } }
 			}
 		}
@@ -34,6 +43,13 @@ describe('Attacks', () => {
 		expect(row).toHaveTextContent('1 B/P/S');
 		expect(row).toHaveTextContent('2 B/P/S');
 		expect(row).toHaveTextContent('3 B/P/S');
+		expect(row).toHaveTextContent('Reach +1 Space');
+		expect(row).toHaveTextContent('Reach');
+		expect(row).toHaveTextContent('Ranged 10 Spaces');
+		expect(row).toHaveTextContent('Concealable');
+		expect(row).toHaveTextContent('Natural Weapon Style');
+		expect(row).toHaveTextContent('Rend');
+		expect(row).toHaveTextContent('Venomous');
 		expect(within(row).queryByRole('combobox')).not.toBeInTheDocument();
 		expect(within(row).queryByTitle('characterSheet.attacksRemoveWeapon')).not.toBeInTheDocument();
 	});

--- a/src/routes/character-sheet/components/Attacks.test.tsx
+++ b/src/routes/character-sheet/components/Attacks.test.tsx
@@ -1,0 +1,40 @@
+import { cleanup, render, screen, within } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import Attacks from './Attacks';
+
+vi.mock('react-i18next', () => ({
+	useTranslation: () => ({ t: (key: string) => key })
+}));
+
+vi.mock('../hooks/CharacterSheetProvider', () => ({
+	useCharacterAttacks: () => [],
+	useCharacterInventory: () => ({ items: [] }),
+	useCharacterCalculatedData: () => ({ conditionalModifiers: [] }),
+	useCharacterSheet: () => ({
+		addAttack: vi.fn(),
+		removeAttack: vi.fn(),
+		updateAttack: vi.fn(),
+		state: {
+			character: {
+				selectedTraitIds: ['beastborn_natural_weapon'],
+				characterState: { ui: { activeConditions: {} } }
+			}
+		}
+	})
+}));
+
+afterEach(cleanup);
+
+describe('Attacks', () => {
+	it('renders Beastborn Natural Weapon as a read-only Unarmed Strike', () => {
+		render(<Attacks onAttackClick={vi.fn()} />);
+
+		const row = screen.getByTestId('natural-weapon-attack-row');
+		expect(row).toHaveTextContent('Natural Weapon (Unarmed Strike)');
+		expect(row).toHaveTextContent('1 B/P/S');
+		expect(row).toHaveTextContent('2 B/P/S');
+		expect(row).toHaveTextContent('3 B/P/S');
+		expect(within(row).queryByRole('combobox')).not.toBeInTheDocument();
+		expect(within(row).queryByTitle('characterSheet.attacksRemoveWeapon')).not.toBeInTheDocument();
+	});
+});

--- a/src/routes/character-sheet/components/Attacks.tsx
+++ b/src/routes/character-sheet/components/Attacks.tsx
@@ -19,6 +19,7 @@ import {
 	getVersatileDamage,
 	createEmptyAttackData
 } from '../../../lib/utils/weaponUtils';
+import { getNaturalWeaponAttack, isNaturalWeaponAttack } from '../naturalWeaponAttack';
 import {
 	StyledAttacksSection,
 	StyledAttacksHeader,
@@ -59,6 +60,12 @@ const InlineEmptyHint = styled.div`
 	padding: ${theme.spacing[2]} 0;
 `;
 
+const DerivedAttackName = styled.div`
+	min-width: 0;
+	color: ${theme.colors.text.primary};
+	font-weight: ${theme.typography.fontWeight.semibold};
+`;
+
 export interface AttacksProps {
 	onAttackClick: (attack: AttackData, weapon: Weapon | null) => void;
 	isMobile?: boolean;
@@ -92,6 +99,8 @@ const Attacks: React.FC<AttacksProps> = ({ onAttackClick, isMobile }) => {
 	const effectiveIsMobile = isMobile || (typeof window !== 'undefined' && window.innerWidth <= 768);
 
 	const characterData = state.character;
+	const naturalWeaponAttack = getNaturalWeaponAttack(characterData.selectedTraitIds);
+	const displayedAttacks = naturalWeaponAttack ? [naturalWeaponAttack, ...attacks] : attacks;
 	const visibleWeapons = showAllWeapons ? weapons : inventoryWeapons;
 	const showNoInventoryWeaponsHint = !showAllWeapons && inventoryWeapons.length === 0;
 	const addWeaponSlot = () => {
@@ -247,12 +256,16 @@ const Attacks: React.FC<AttacksProps> = ({ onAttackClick, isMobile }) => {
 					</StyledHeaderColumn>
 				</StyledAttacksHeaderRow>
 
-				{attacks.length === 0 ? (
+				{displayedAttacks.length === 0 ? (
 					<StyledEmptyState $isMobile={effectiveIsMobile}>
 						{t('characterSheet.attacksNoWeapons')}
 					</StyledEmptyState>
 				) : (
-					attacks.map((attack, index) => {
+					displayedAttacks.map((attack, index) => {
+						const isDerivedNaturalWeapon = isNaturalWeaponAttack(attack);
+						const persistedAttackIndex = attacks.findIndex(
+							(persistedAttack) => persistedAttack.id === attack.id
+						);
 						const weapon = attack.weaponName
 							? weapons.find((w) => w.name === attack.weaponName)
 							: null;
@@ -269,36 +282,49 @@ const Attacks: React.FC<AttacksProps> = ({ onAttackClick, isMobile }) => {
 						});
 
 						return (
-							<StyledAttackRow $isMobile={effectiveIsMobile} key={attack.id}>
-								{/* Remove Button */}
-								<DeleteButton
-									onClick={() => removeWeaponSlot(index)}
-									title={t('characterSheet.attacksRemoveWeapon')}
-									$isMobile={effectiveIsMobile}
-								/>
+							<StyledAttackRow
+								$isMobile={effectiveIsMobile}
+								key={attack.id}
+								data-testid={isDerivedNaturalWeapon ? 'natural-weapon-attack-row' : undefined}
+							>
+								{isDerivedNaturalWeapon ? (
+									<span aria-hidden="true" />
+								) : (
+									<DeleteButton
+										onClick={() => removeWeaponSlot(persistedAttackIndex)}
+										title={t('characterSheet.attacksRemoveWeapon')}
+										$isMobile={effectiveIsMobile}
+									/>
+								)}
 
 								{/* Weapon Selection */}
-								<StyledWeaponSelect
-									$isMobile={effectiveIsMobile}
-									value={attack.weaponName}
-									onChange={(e: any) => handleWeaponSelect(index, e.target.value)}
-									data-testid="weapon-name"
-								>
-									<option value="">{t('characterSheet.attacksSelectWeapon')}</option>
-									{visibleWeapons.map((weapon) => (
-										<option key={weapon.name} value={weapon.name}>
-											{weapon.name} ({weapon.handedness})
-										</option>
-									))}
-									{/* Keep the saved weapon visible even if it's no longer in
-									    inventory (e.g. user sold it) so the row doesn't appear blank. */}
-									{attack.weaponName &&
-										!visibleWeapons.some((w) => w.name === attack.weaponName) && (
-											<option key={attack.weaponName} value={attack.weaponName}>
-												{attack.weaponName} {t('characterSheet.attacksNotInInventory')}
+								{isDerivedNaturalWeapon ? (
+									<DerivedAttackName data-testid="natural-weapon-attack">
+										{attack.name}
+									</DerivedAttackName>
+								) : (
+									<StyledWeaponSelect
+										$isMobile={effectiveIsMobile}
+										value={attack.weaponName}
+										onChange={(e: any) => handleWeaponSelect(persistedAttackIndex, e.target.value)}
+										data-testid="weapon-name"
+									>
+										<option value="">{t('characterSheet.attacksSelectWeapon')}</option>
+										{visibleWeapons.map((weapon) => (
+											<option key={weapon.name} value={weapon.name}>
+												{weapon.name} ({weapon.handedness})
 											</option>
-										)}
-								</StyledWeaponSelect>
+										))}
+										{/* Keep the saved weapon visible even if it's no longer in
+										    inventory (e.g. user sold it) so the row doesn't appear blank. */}
+										{attack.weaponName &&
+											!visibleWeapons.some((w) => w.name === attack.weaponName) && (
+												<option key={attack.weaponName} value={attack.weaponName}>
+													{attack.weaponName} {t('characterSheet.attacksNotInInventory')}
+												</option>
+											)}
+									</StyledWeaponSelect>
+								)}
 
 								{/* Base Damage */}
 								<StyledDamageCell
@@ -362,7 +388,7 @@ const Attacks: React.FC<AttacksProps> = ({ onAttackClick, isMobile }) => {
 
 								{/* Damage Calculation Info */}
 								<div style={{ textAlign: 'center', fontSize: '1.1rem' }}>
-									{weapon ? (
+									{presentation.isSupportedAttack ? (
 										<StyledInfoIcon
 											$isMobile={effectiveIsMobile}
 											onClick={() => onAttackClick(attack, weapon)}

--- a/src/routes/character-sheet/components/Attacks.tsx
+++ b/src/routes/character-sheet/components/Attacks.tsx
@@ -12,6 +12,7 @@ import {
 import { getAttackPresentation } from '../attackPresentation';
 import { logger } from '../../../lib/utils/logger';
 import DeleteButton from './shared/DeleteButton';
+import RowEditControls from './shared/RowEditControls';
 import {
 	parseDamage,
 	getDamageType,
@@ -20,6 +21,7 @@ import {
 	createEmptyAttackData
 } from '../../../lib/utils/weaponUtils';
 import { getNaturalWeaponAttack, isNaturalWeaponAttack } from '../naturalWeaponAttack';
+import { getAncestryAttackTraits } from '../ancestryAttackTraits';
 import {
 	StyledAttacksSection,
 	StyledAttacksHeader,
@@ -31,6 +33,11 @@ import {
 	StyledEmptyState,
 	StyledAttackRow,
 	StyledWeaponSelect,
+	StyledWeaponName,
+	StyledAttackIdentity,
+	StyledAttackProperties,
+	StyledAttackProperty,
+	StyledAttackTraitNotes,
 	StyledDamageCell,
 	StyledInfoIcon,
 	StyledDamageTypeCell
@@ -60,24 +67,26 @@ const InlineEmptyHint = styled.div`
 	padding: ${theme.spacing[2]} 0;
 `;
 
-const DerivedAttackName = styled.div`
-	min-width: 0;
-	color: ${theme.colors.text.primary};
-	font-weight: ${theme.typography.fontWeight.semibold};
-`;
-
 export interface AttacksProps {
 	onAttackClick: (attack: AttackData, weapon: Weapon | null) => void;
 	isMobile?: boolean;
+	showTitle?: boolean;
+	explicitEditMode?: boolean;
 }
 
-const Attacks: React.FC<AttacksProps> = ({ onAttackClick, isMobile }) => {
+const Attacks: React.FC<AttacksProps> = ({
+	onAttackClick,
+	isMobile,
+	showTitle = true,
+	explicitEditMode = false
+}) => {
 	const { t } = useTranslation();
 	const { addAttack, removeAttack, updateAttack, state } = useCharacterSheet();
 	const attacks = useCharacterAttacks();
 	const inventory = useCharacterInventory();
 	const calculation = useCharacterCalculatedData();
 	const [showAllWeapons, setShowAllWeapons] = useState(false);
+	const [editingAttackIds, setEditingAttackIds] = useState<Set<string>>(new Set());
 
 	// Build the list of weapons currently in the character's inventory by matching
 	// inventory item names against the global weapons catalog. This becomes the
@@ -117,13 +126,30 @@ const Attacks: React.FC<AttacksProps> = ({ onAttackClick, isMobile }) => {
 			heavyHitEffect: ''
 		};
 		addAttack(newAttack);
+		if (explicitEditMode) {
+			setEditingAttackIds((current) => new Set(current).add(newAttack.id));
+		}
 	};
 
 	const removeWeaponSlot = (attackIndex: number) => {
 		const attackToRemove = attacks[attackIndex];
 		if (attackToRemove) {
 			removeAttack(attackToRemove.id);
+			setEditingAttackIds((current) => {
+				const next = new Set(current);
+				next.delete(attackToRemove.id);
+				return next;
+			});
 		}
+	};
+
+	const toggleAttackEditing = (attackId: string) => {
+		setEditingAttackIds((current) => {
+			const next = new Set(current);
+			if (next.has(attackId)) next.delete(attackId);
+			else next.add(attackId);
+			return next;
+		});
 	};
 
 	const handleWeaponSelect = (attackIndex: number, weaponName: string) => {
@@ -187,9 +213,11 @@ const Attacks: React.FC<AttacksProps> = ({ onAttackClick, isMobile }) => {
 	return (
 		<StyledAttacksSection $isMobile={effectiveIsMobile}>
 			<StyledAttacksHeader $isMobile={effectiveIsMobile}>
-				<StyledAttacksTitle $isMobile={effectiveIsMobile}>
-					{t('characterSheet.attacksTitle')}
-				</StyledAttacksTitle>
+				{showTitle && (
+					<StyledAttacksTitle $isMobile={effectiveIsMobile}>
+						{t('characterSheet.attacksTitle')}
+					</StyledAttacksTitle>
+				)}
 				<div style={{ display: 'flex', alignItems: 'center' }}>
 					<FilterToggleRow>
 						<input
@@ -213,8 +241,8 @@ const Attacks: React.FC<AttacksProps> = ({ onAttackClick, isMobile }) => {
 			)}
 
 			<StyledAttacksContainer $isMobile={effectiveIsMobile}>
-				<StyledAttacksHeaderRow $isMobile={effectiveIsMobile}>
-					<span></span> {/* Empty column for remove button */}
+				<StyledAttacksHeaderRow $isMobile={effectiveIsMobile} $explicitEditMode={explicitEditMode}>
+					{!explicitEditMode && <span aria-hidden="true" />}
 					<StyledHeaderColumn $isMobile={effectiveIsMobile}>
 						{t('characterSheet.attacksColumnWeapon')}
 					</StyledHeaderColumn>
@@ -254,6 +282,7 @@ const Attacks: React.FC<AttacksProps> = ({ onAttackClick, isMobile }) => {
 					<StyledHeaderColumn $isMobile={effectiveIsMobile} $align="center">
 						<StyledInfoIcon $isMobile={effectiveIsMobile}>i</StyledInfoIcon>
 					</StyledHeaderColumn>
+					{explicitEditMode && <span aria-hidden="true" />}
 				</StyledAttacksHeaderRow>
 
 				{displayedAttacks.length === 0 ? (
@@ -274,35 +303,48 @@ const Attacks: React.FC<AttacksProps> = ({ onAttackClick, isMobile }) => {
 						)
 							.filter(([, enabled]) => Boolean(enabled))
 							.map(([condition]) => condition);
-						const presentation = getAttackPresentation({
+						const basePresentation = getAttackPresentation({
 							attack,
 							weapon,
 							conditionalModifiers: calculation?.conditionalModifiers,
 							activeConditions
 						});
+						const traitPresentation = getAncestryAttackTraits({
+							selectedTraitIds: characterData.selectedTraitIds,
+							isNaturalWeapon: isDerivedNaturalWeapon,
+							isMartialMelee: basePresentation.isMartialMelee,
+							isSupportedAttack: basePresentation.isSupportedAttack
+						});
+						const presentation = getAttackPresentation({
+							attack,
+							weapon,
+							conditionalModifiers: calculation?.conditionalModifiers,
+							activeConditions,
+							brutalDamageBonus: traitPresentation.brutalDamageBonus
+						});
+						const isEditing =
+							!isDerivedNaturalWeapon && (!explicitEditMode || editingAttackIds.has(attack.id));
 
 						return (
 							<StyledAttackRow
 								$isMobile={effectiveIsMobile}
+								$explicitEditMode={explicitEditMode}
 								key={attack.id}
 								data-testid={isDerivedNaturalWeapon ? 'natural-weapon-attack-row' : undefined}
 							>
-								{isDerivedNaturalWeapon ? (
-									<span aria-hidden="true" />
-								) : (
-									<DeleteButton
-										onClick={() => removeWeaponSlot(persistedAttackIndex)}
-										title={t('characterSheet.attacksRemoveWeapon')}
-										$isMobile={effectiveIsMobile}
-									/>
-								)}
+								{!explicitEditMode &&
+									(isDerivedNaturalWeapon ? (
+										<span aria-hidden="true" />
+									) : (
+										<DeleteButton
+											onClick={() => removeWeaponSlot(persistedAttackIndex)}
+											title={t('characterSheet.attacksRemoveWeapon')}
+											$isMobile={effectiveIsMobile}
+										/>
+									))}
 
 								{/* Weapon Selection */}
-								{isDerivedNaturalWeapon ? (
-									<DerivedAttackName data-testid="natural-weapon-attack">
-										{attack.name}
-									</DerivedAttackName>
-								) : (
+								{isEditing ? (
 									<StyledWeaponSelect
 										$isMobile={effectiveIsMobile}
 										value={attack.weaponName}
@@ -315,8 +357,6 @@ const Attacks: React.FC<AttacksProps> = ({ onAttackClick, isMobile }) => {
 												{weapon.name} ({weapon.handedness})
 											</option>
 										))}
-										{/* Keep the saved weapon visible even if it's no longer in
-										    inventory (e.g. user sold it) so the row doesn't appear blank. */}
 										{attack.weaponName &&
 											!visibleWeapons.some((w) => w.name === attack.weaponName) && (
 												<option key={attack.weaponName} value={attack.weaponName}>
@@ -324,6 +364,32 @@ const Attacks: React.FC<AttacksProps> = ({ onAttackClick, isMobile }) => {
 												</option>
 											)}
 									</StyledWeaponSelect>
+								) : (
+									<StyledAttackIdentity>
+										<StyledWeaponName
+											data-testid={isDerivedNaturalWeapon ? 'natural-weapon-attack' : undefined}
+										>
+											{isDerivedNaturalWeapon
+												? attack.name
+												: attack.weaponName || t('characterSheet.attacksSelectWeapon')}
+										</StyledWeaponName>
+										{traitPresentation.properties.length > 0 && (
+											<StyledAttackProperties aria-label="Attack properties">
+												{traitPresentation.properties.map((property) => (
+													<StyledAttackProperty key={property}>{property}</StyledAttackProperty>
+												))}
+											</StyledAttackProperties>
+										)}
+										{traitPresentation.notes.length > 0 && (
+											<StyledAttackTraitNotes aria-label="Attack trait notes">
+												{traitPresentation.notes.map((note) => (
+													<span key={`${note.source}-${note.text}`}>
+														<strong>{note.source}:</strong> {note.text}
+													</span>
+												))}
+											</StyledAttackTraitNotes>
+										)}
+									</StyledAttackIdentity>
 								)}
 
 								{/* Base Damage */}
@@ -401,6 +467,19 @@ const Attacks: React.FC<AttacksProps> = ({ onAttackClick, isMobile }) => {
 										'-'
 									)}
 								</div>
+
+								{explicitEditMode &&
+									(isDerivedNaturalWeapon ? (
+										<span aria-hidden="true" />
+									) : (
+										<RowEditControls
+											isEditing={isEditing}
+											onToggle={() => toggleAttackEditing(attack.id)}
+											onDelete={() => removeWeaponSlot(persistedAttackIndex)}
+											itemLabel="weapon"
+											isMobile={effectiveIsMobile}
+										/>
+									))}
 							</StyledAttackRow>
 						);
 					})

--- a/src/routes/character-sheet/components/DiceRoller.tsx
+++ b/src/routes/character-sheet/components/DiceRoller.tsx
@@ -59,7 +59,7 @@ interface DiceRollerProps {
 		total: number,
 		rollMode: RollMode,
 		modifier: number,
-		label: string,
+		label: string
 	) => void;
 }
 
@@ -288,7 +288,12 @@ const DiceRoller = forwardRef<DiceRollerRef, DiceRollerProps>(({ onRoll }, ref) 
 
 	return (
 		<StyledDiceRollerContainer $isExpanded={isExpanded}>
-			<StyledCollapseButton onClick={() => setIsExpanded(!isExpanded)} $isExpanded={isExpanded}>
+			<StyledCollapseButton
+				onClick={() => setIsExpanded(!isExpanded)}
+				$isExpanded={isExpanded}
+				aria-expanded={isExpanded}
+				aria-label="Toggle dice roller"
+			>
 				🎲
 			</StyledCollapseButton>
 

--- a/src/routes/character-sheet/components/Features.tsx
+++ b/src/routes/character-sheet/components/Features.tsx
@@ -17,9 +17,10 @@ import {
 interface FeaturesProps {
 	onFeatureClick: (feature: FeatureData) => void;
 	isMobile?: boolean;
+	showTitle?: boolean;
 }
 
-const Features: React.FC<FeaturesProps> = ({ onFeatureClick, isMobile }) => {
+const Features: React.FC<FeaturesProps> = ({ onFeatureClick, isMobile, showTitle = true }) => {
 	const { t } = useTranslation();
 	const { state } = useCharacterSheet();
 	const features = useCharacterFeatures(); // Use our enhanced hook!
@@ -40,9 +41,11 @@ const Features: React.FC<FeaturesProps> = ({ onFeatureClick, isMobile }) => {
 
 	return (
 		<StyledFeaturesContainer $isMobile={effectiveIsMobile}>
-			<StyledFeaturesTitle $isMobile={effectiveIsMobile}>
-				{t('characterSheet.featuresTitle')}
-			</StyledFeaturesTitle>
+			{showTitle && (
+				<StyledFeaturesTitle $isMobile={effectiveIsMobile}>
+					{t('characterSheet.featuresTitle')}
+				</StyledFeaturesTitle>
+			)}
 
 			<StyledFeaturesContent $isMobile={effectiveIsMobile}>
 				{/* Ancestry Traits */}

--- a/src/routes/character-sheet/components/Inventory.tsx
+++ b/src/routes/character-sheet/components/Inventory.tsx
@@ -6,6 +6,7 @@ import { allItems, type InventoryItem } from '../../../lib/rulesdata/inventoryIt
 import { getAllCustomEquipment } from '../../../lib/rulesdata/equipment/storage/equipmentStorage';
 import { useCharacterInventory, useCharacterSheet } from '../hooks/CharacterSheetProvider';
 import DeleteButton from './shared/DeleteButton';
+import RowEditControls from './shared/RowEditControls';
 import {
 	StyledInventorySection,
 	StyledInventoryTitle,
@@ -20,7 +21,8 @@ import {
 	StyledInventoryInfoIcon,
 	StyledInventoryCost,
 	StyledEmptyInventory,
-	StyledInventoryCheckbox
+	StyledInventoryCheckbox,
+	StyledInventoryValue
 } from '../styles/Inventory';
 import { theme } from '../styles/theme';
 
@@ -80,9 +82,18 @@ function formatCustomEquipmentCategory(
 export interface InventoryProps {
 	onItemClick: (inventoryData: InventoryItemData, item: InventoryItem | null) => void;
 	isMobile?: boolean;
+	showInfoHeader?: boolean;
+	showTitle?: boolean;
+	explicitEditMode?: boolean;
 }
 
-const Inventory: React.FC<InventoryProps> = ({ onItemClick, isMobile = false }) => {
+const Inventory: React.FC<InventoryProps> = ({
+	onItemClick,
+	isMobile = false,
+	showInfoHeader = true,
+	showTitle = true,
+	explicitEditMode = false
+}) => {
 	const { t } = useTranslation();
 	const { updateInventory } = useCharacterSheet();
 	const inventoryData = useCharacterInventory();
@@ -93,6 +104,7 @@ const Inventory: React.FC<InventoryProps> = ({ onItemClick, isMobile = false }) 
 
 	// Track which Custom inventory slots are in freeform text-input mode (by item id)
 	const [freeformItemIds, setFreeformItemIds] = useState<Set<string>>(new Set());
+	const [editingItemIds, setEditingItemIds] = useState<Set<string>>(new Set());
 
 	// On mount / when inventory changes, initialise freeform set from persisted data:
 	// any Custom item that has a name but no customEquipmentId is freeform.
@@ -121,6 +133,9 @@ const Inventory: React.FC<InventoryProps> = ({ onItemClick, isMobile = false }) 
 			isEquipped: false
 		};
 		updateInventory([...inventory, newInventoryItem]);
+		if (explicitEditMode) {
+			setEditingItemIds((current) => new Set(current).add(newInventoryItem.id));
+		}
 	};
 
 	const removeInventorySlot = (inventoryIndex: number) => {
@@ -129,12 +144,26 @@ const Inventory: React.FC<InventoryProps> = ({ onItemClick, isMobile = false }) 
 		updateInventory(updatedInventory);
 		// Clean up freeform tracking
 		if (removedItem) {
+			setEditingItemIds((current) => {
+				const next = new Set(current);
+				next.delete(removedItem.id);
+				return next;
+			});
 			setFreeformItemIds((prev) => {
 				const next = new Set(prev);
 				next.delete(removedItem.id);
 				return next;
 			});
 		}
+	};
+
+	const toggleItemEditing = (itemId: string) => {
+		setEditingItemIds((current) => {
+			const next = new Set(current);
+			if (next.has(itemId)) next.delete(itemId);
+			else next.add(itemId);
+			return next;
+		});
 	};
 
 	const handleInventoryItemSelect = (
@@ -443,9 +472,11 @@ const Inventory: React.FC<InventoryProps> = ({ onItemClick, isMobile = false }) 
 
 	return (
 		<StyledInventorySection $isMobile={isMobile}>
-			<StyledInventoryTitle $isMobile={isMobile}>
-				{t('characterSheet.inventoryTitle')}
-			</StyledInventoryTitle>
+			{showTitle && (
+				<StyledInventoryTitle $isMobile={isMobile}>
+					{t('characterSheet.inventoryTitle')}
+				</StyledInventoryTitle>
+			)}
 
 			{/* Add Item Button */}
 			<StyledAddItemButton $isMobile={isMobile} onClick={addInventorySlot} data-testid="add-item">
@@ -453,8 +484,8 @@ const Inventory: React.FC<InventoryProps> = ({ onItemClick, isMobile = false }) 
 			</StyledAddItemButton>
 
 			<StyledInventoryContainer $isMobile={isMobile}>
-				<StyledInventoryHeaderRow>
-					<span></span> {/* Empty column for remove button */}
+				<StyledInventoryHeaderRow $explicitEditMode={explicitEditMode}>
+					{!explicitEditMode && <span aria-hidden="true" />}
 					<StyledInventoryHeaderColumn align="center">Eq.</StyledInventoryHeaderColumn>
 					<StyledInventoryHeaderColumn>
 						{t('characterSheet.inventoryColumnType')}
@@ -466,11 +497,12 @@ const Inventory: React.FC<InventoryProps> = ({ onItemClick, isMobile = false }) 
 						{t('characterSheet.inventoryColumnCount')}
 					</StyledInventoryHeaderColumn>
 					<StyledInventoryHeaderColumn align="center">
-						<StyledInventoryInfoIcon>i</StyledInventoryInfoIcon>
+						{showInfoHeader ? <StyledInventoryInfoIcon>i</StyledInventoryInfoIcon> : null}
 					</StyledInventoryHeaderColumn>
 					<StyledInventoryHeaderColumn align="center">
 						{t('characterSheet.inventoryColumnCost')}
 					</StyledInventoryHeaderColumn>
+					{explicitEditMode && <span aria-hidden="true" />}
 				</StyledInventoryHeaderRow>
 
 				{inventory.length === 0 ? (
@@ -485,48 +517,60 @@ const Inventory: React.FC<InventoryProps> = ({ onItemClick, isMobile = false }) 
 
 						// For Custom items, determine if the info icon should be clickable
 						const hasCustomInfo = isCustomType && !!item.itemName;
+						const isEditing = !explicitEditMode || editingItemIds.has(item.id);
 
 						return (
-							<StyledInventoryRow key={item.id}>
-								{/* Remove Button */}
-								<DeleteButton
-									onClick={() => removeInventorySlot(index)}
-									title={t('characterSheet.inventoryRemoveItem')}
-									$isMobile={isMobile}
-								/>
+							<StyledInventoryRow key={item.id} $explicitEditMode={explicitEditMode}>
+								{!explicitEditMode && (
+									<DeleteButton
+										onClick={() => removeInventorySlot(index)}
+										title={t('characterSheet.inventoryRemoveItem')}
+										$isMobile={isMobile}
+									/>
+								)}
 
 								<StyledInventoryCheckbox
 									$isMobile={isMobile}
 									type="checkbox"
 									checked={!!item.isEquipped}
-									disabled={!item.itemName}
+									disabled={!item.itemName || !isEditing}
 									onChange={(e) => handleEquippedChange(index, e.target.checked)}
 									title="Equipped"
 									aria-label={`item-equipped-${index + 1}`}
 								/>
 
 								{/* Item Type */}
-								<StyledInventorySelect
-									$isMobile={isMobile}
-									value={item.itemType}
-									onChange={(e) => handleInventoryItemSelect(index, e.target.value, false)}
-								>
-									<option value="">{t('characterSheet.inventorySelectType')}</option>
-									<option value="Weapon">Weapon</option>
-									<option value="Armor">Armor</option>
-									<option value="Shield">Shield</option>
-									<option value="Adventuring Supply">Adventuring Supply</option>
-									<option value="Potion">Healing Potion</option>
-									<option value="Custom">
+								{isEditing ? (
+									<StyledInventorySelect
+										$isMobile={isMobile}
+										value={item.itemType}
+										onChange={(e) => handleInventoryItemSelect(index, e.target.value, false)}
+									>
+										<option value="">{t('characterSheet.inventorySelectType')}</option>
+										<option value="Weapon">Weapon</option>
+										<option value="Armor">Armor</option>
+										<option value="Shield">Shield</option>
+										<option value="Adventuring Supply">Adventuring Supply</option>
+										<option value="Potion">Healing Potion</option>
+										<option value="Custom">
+											{isCustomType
+												? formatCustomEquipmentCategory(item.customEquipmentCategory)
+												: 'Custom'}
+										</option>
+									</StyledInventorySelect>
+								) : (
+									<StyledInventoryValue>
 										{isCustomType
 											? formatCustomEquipmentCategory(item.customEquipmentCategory)
-											: 'Custom'}
-									</option>
-								</StyledInventorySelect>
+											: item.itemType || '—'}
+									</StyledInventoryValue>
+								)}
 
 								{/* Item Name + inline summary stacked in the same grid cell */}
 								<ItemNameCell>
-									{isCustomType ? (
+									{!isEditing ? (
+										<StyledInventoryValue>{item.itemName || '—'}</StyledInventoryValue>
+									) : isCustomType ? (
 										renderCustomNameColumn(item, index)
 									) : (
 										<StyledInventorySelect
@@ -556,13 +600,19 @@ const Inventory: React.FC<InventoryProps> = ({ onItemClick, isMobile = false }) 
 								</ItemNameCell>
 
 								{/* Count */}
-								<StyledInventoryInput
-									$isMobile={isMobile}
-									type="number"
-									min="1"
-									value={item.count}
-									onChange={(e) => handleInventoryCountChange(index, parseInt(e.target.value) || 1)}
-								/>
+								{isEditing ? (
+									<StyledInventoryInput
+										$isMobile={isMobile}
+										type="number"
+										min="1"
+										value={item.count}
+										onChange={(e) =>
+											handleInventoryCountChange(index, parseInt(e.target.value) || 1)
+										}
+									/>
+								) : (
+									<StyledInventoryValue $centered>{item.count}</StyledInventoryValue>
+								)}
 
 								{/* Info Indicator — accent variant when a custom item has a description */}
 								<div style={{ textAlign: 'center' }}>
@@ -608,6 +658,16 @@ const Inventory: React.FC<InventoryProps> = ({ onItemClick, isMobile = false }) 
 								<StyledInventoryCost>
 									{isCustomType ? item.cost || '-' : getItemCost(selectedItem, item.count)}
 								</StyledInventoryCost>
+
+								{explicitEditMode && (
+									<RowEditControls
+										isEditing={isEditing}
+										onToggle={() => toggleItemEditing(item.id)}
+										onDelete={() => removeInventorySlot(index)}
+										itemLabel="inventory item"
+										isMobile={isMobile}
+									/>
+								)}
 							</StyledInventoryRow>
 						);
 					})

--- a/src/routes/character-sheet/components/Maneuvers.tsx
+++ b/src/routes/character-sheet/components/Maneuvers.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Check, Pencil } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import type { ManeuverData } from '../../../types';
 import type { Maneuver } from '../../../lib/rulesdata/martials/maneuvers';
@@ -16,7 +15,7 @@ import {
 } from '../hooks/CharacterSheetProvider';
 import { calculateEnhancementStaminaSpend } from '../maneuverEnhancementSpend';
 import { logger } from '../../../lib/utils/logger';
-import DeleteButton from './shared/DeleteButton';
+import RowEditControls from './shared/RowEditControls';
 import RichDescription from './RichDescription';
 import {
 	StyledManeuversSection,
@@ -54,13 +53,15 @@ export interface ManeuversProps {
 	onManeuverUse?: (maneuver: ManeuverData) => void;
 	readOnly?: boolean;
 	isMobile?: boolean;
+	showTitle?: boolean;
 }
 
 const Maneuvers: React.FC<ManeuversProps> = ({
 	onManeuverClick: _onManeuverClick,
 	onManeuverUse,
 	readOnly = false,
-	isMobile
+	isMobile,
+	showTitle = true
 }) => {
 	const { t } = useTranslation();
 	const { addManeuver, removeManeuver, state } = useCharacterSheet();
@@ -215,7 +216,9 @@ const Maneuvers: React.FC<ManeuversProps> = ({
 	return (
 		<StyledManeuversSection $isMobile={effectiveIsMobile}>
 			<StyledManeuversHeader $isMobile={effectiveIsMobile}>
-				<StyledManeuversTitle $isMobile={effectiveIsMobile}>Maneuvers</StyledManeuversTitle>
+				{showTitle && (
+					<StyledManeuversTitle $isMobile={effectiveIsMobile}>Maneuvers</StyledManeuversTitle>
+				)}
 				<StyledManeuversControls $isMobile={effectiveIsMobile}>
 					{!readOnly && (
 						<>
@@ -401,25 +404,13 @@ const Maneuvers: React.FC<ManeuversProps> = ({
 											</StyledManeuverActionButton>
 										)}
 										{!readOnly && (
-											<StyledManeuverActionButton
-												onClick={() => toggleManeuverEditing(maneuver.id)}
-												aria-label={
-													isEditing ? 'Finish Editing Maneuver Slot' : 'Edit Maneuver Slot'
-												}
-												title={isEditing ? 'Finish editing maneuver slot' : 'Edit maneuver slot'}
-												data-testid={`edit-maneuver-${maneuver.id}`}
-											>
-												{isEditing ? <Check size={14} /> : <Pencil size={14} />}
-											</StyledManeuverActionButton>
-										)}
-										{!readOnly && isEditing && (
-											<DeleteButton
-												onClick={(event) => {
-													event.stopPropagation();
-													removeManeuverSlot(originalIndex);
-												}}
-												title="Remove maneuver slot"
-												$isMobile={effectiveIsMobile}
+											<RowEditControls
+												isEditing={isEditing}
+												onToggle={() => toggleManeuverEditing(maneuver.id)}
+												onDelete={() => removeManeuverSlot(originalIndex)}
+												itemLabel="maneuver slot"
+												isMobile={effectiveIsMobile}
+												toggleTestId={`edit-maneuver-${maneuver.id}`}
 											/>
 										)}
 									</StyledManeuverActions>

--- a/src/routes/character-sheet/components/PlayerNotes.tsx
+++ b/src/routes/character-sheet/components/PlayerNotes.tsx
@@ -8,11 +8,13 @@ import {
 	StyledNotesList,
 	StyledNoteItem,
 	StyledNoteInput,
+	StyledNoteText,
 	StyledAddButton,
 	StyledDeleteButton,
 	StyledEmptyNotesMessage,
 	StyledAddNoteSection
 } from '../styles/PlayerNotes.styles';
+import RowEditControls from './shared/RowEditControls';
 
 // Multi-note data model. Stored inside the existing `notes.playerNotes` string
 // field as a JSON-encoded array so we don't need to migrate the reducer/schema.
@@ -64,7 +66,15 @@ function serializeNotes(notes: Note[]): string {
 	return NOTES_JSON_MARKER + JSON.stringify(notes);
 }
 
-const PlayerNotes: React.FC = () => {
+interface PlayerNotesProps {
+	showTitle?: boolean;
+	explicitEditMode?: boolean;
+}
+
+const PlayerNotes: React.FC<PlayerNotesProps> = ({
+	showTitle = true,
+	explicitEditMode = false
+}) => {
 	const { t } = useTranslation();
 	const { updateNotes, state } = useCharacterSheet();
 
@@ -74,6 +84,7 @@ const PlayerNotes: React.FC = () => {
 	// Local edit state for title — body edits flow directly to storage so they're
 	// auto-saved like every other field on the sheet.
 	const [editingTitleId, setEditingTitleId] = useState<string | null>(null);
+	const [editingNoteIds, setEditingNoteIds] = useState<Set<string>>(new Set());
 
 	if (!state.character) {
 		return (
@@ -95,7 +106,11 @@ const PlayerNotes: React.FC = () => {
 			createdAt: new Date().toISOString()
 		};
 		persist([...notes, newNote]);
-		setEditingTitleId(newNote.id);
+		if (explicitEditMode) {
+			setEditingNoteIds((current) => new Set(current).add(newNote.id));
+		} else {
+			setEditingTitleId(newNote.id);
+		}
 	};
 
 	const handleUpdateBody = (id: string, body: string) => {
@@ -110,6 +125,20 @@ const PlayerNotes: React.FC = () => {
 		const confirmed = window.confirm(t('characterSheet.notesDeleteConfirm'));
 		if (!confirmed) return;
 		persist(notes.filter((n) => n.id !== id));
+		setEditingNoteIds((current) => {
+			const next = new Set(current);
+			next.delete(id);
+			return next;
+		});
+	};
+
+	const toggleNoteEditing = (id: string) => {
+		setEditingNoteIds((current) => {
+			const next = new Set(current);
+			if (next.has(id)) next.delete(id);
+			else next.add(id);
+			return next;
+		});
 	};
 
 	return (
@@ -123,9 +152,11 @@ const PlayerNotes: React.FC = () => {
 					gap: '1rem'
 				}}
 			>
-				<StyledPlayerNotesTitle style={{ margin: 0, textAlign: 'left', flex: 1 }}>
-					{t('characterSheet.notesTitle')}
-				</StyledPlayerNotesTitle>
+				{showTitle && (
+					<StyledPlayerNotesTitle style={{ margin: 0, textAlign: 'left', flex: 1 }}>
+						{t('characterSheet.notesTitle')}
+					</StyledPlayerNotesTitle>
+				)}
 				<StyledAddButton onClick={handleAddNote} type="button">
 					+ {t('characterSheet.notesNewNote')}
 				</StyledAddButton>
@@ -136,75 +167,100 @@ const PlayerNotes: React.FC = () => {
 					<StyledEmptyNotesMessage>{t('characterSheet.notesEmpty')}</StyledEmptyNotesMessage>
 				) : (
 					<StyledNotesList>
-						{notes.map((note) => (
-							<StyledNoteItem key={note.id}>
-								<div
-									style={{
-										display: 'flex',
-										justifyContent: 'space-between',
-										alignItems: 'center',
-										gap: '0.5rem',
-										marginBottom: '0.5rem'
-									}}
-								>
-									{editingTitleId === note.id ? (
-										<input
-											type="text"
-											value={note.title}
-											onChange={(e) => handleUpdateTitle(note.id, e.target.value)}
-											onBlur={() => setEditingTitleId(null)}
-											onKeyDown={(e) => {
-												if (e.key === 'Enter' || e.key === 'Escape') {
-													(e.target as HTMLInputElement).blur();
-												}
-											}}
-											autoFocus
-											style={{
-												flex: 1,
-												background: 'transparent',
-												border: '1px solid #555',
-												borderRadius: '4px',
-												color: '#fff',
-												padding: '0.25rem 0.5rem',
-												fontSize: '0.95rem',
-												fontWeight: 600
-											}}
+						{notes.map((note) => {
+							const isEditing = explicitEditMode
+								? editingNoteIds.has(note.id)
+								: editingTitleId === note.id;
+
+							return (
+								<StyledNoteItem key={note.id}>
+									<div
+										style={{
+											display: 'flex',
+											justifyContent: 'space-between',
+											alignItems: 'center',
+											gap: '0.5rem',
+											marginBottom: '0.5rem'
+										}}
+									>
+										{isEditing ? (
+											<input
+												type="text"
+												value={note.title}
+												onChange={(e) => handleUpdateTitle(note.id, e.target.value)}
+												onBlur={() => {
+													if (!explicitEditMode) setEditingTitleId(null);
+												}}
+												onKeyDown={(e) => {
+													if (!explicitEditMode && (e.key === 'Enter' || e.key === 'Escape')) {
+														(e.target as HTMLInputElement).blur();
+													}
+												}}
+												autoFocus
+												style={{
+													flex: 1,
+													background: 'transparent',
+													border: '1px solid #555',
+													borderRadius: '4px',
+													color: '#fff',
+													padding: '0.25rem 0.5rem',
+													fontSize: '0.95rem',
+													fontWeight: 600
+												}}
+											/>
+										) : (
+											<button
+												type="button"
+												onClick={() => {
+													if (!explicitEditMode) setEditingTitleId(note.id);
+												}}
+												title={t('characterSheet.notesEditTitle')}
+												style={{
+													flex: 1,
+													textAlign: 'left',
+													background: 'transparent',
+													border: 'none',
+													color: '#fff',
+													padding: '0.25rem 0',
+													fontSize: '0.95rem',
+													fontWeight: 600,
+													cursor: explicitEditMode ? 'default' : 'text'
+												}}
+											>
+												{note.title || t('characterSheet.notesUntitled')}
+											</button>
+										)}
+										{explicitEditMode ? (
+											<RowEditControls
+												isEditing={isEditing}
+												onToggle={() => toggleNoteEditing(note.id)}
+												onDelete={() => handleDeleteNote(note.id)}
+												itemLabel="note"
+											/>
+										) : (
+											<StyledDeleteButton
+												onClick={() => handleDeleteNote(note.id)}
+												title={t('characterSheet.notesDelete')}
+												type="button"
+											>
+												×
+											</StyledDeleteButton>
+										)}
+									</div>
+									{!explicitEditMode || isEditing ? (
+										<StyledNoteInput
+											value={note.body}
+											onChange={(e) => handleUpdateBody(note.id, e.target.value)}
+											placeholder={t('characterSheet.notesPlaceholder')}
 										/>
 									) : (
-										<button
-											type="button"
-											onClick={() => setEditingTitleId(note.id)}
-											title={t('characterSheet.notesEditTitle')}
-											style={{
-												flex: 1,
-												textAlign: 'left',
-												background: 'transparent',
-												border: 'none',
-												color: '#fff',
-												padding: '0.25rem 0',
-												fontSize: '0.95rem',
-												fontWeight: 600,
-												cursor: 'text'
-											}}
-										>
-											{note.title || t('characterSheet.notesUntitled')}
-										</button>
+										<StyledNoteText>
+											{note.body || t('characterSheet.notesPlaceholder')}
+										</StyledNoteText>
 									)}
-									<StyledDeleteButton
-										onClick={() => handleDeleteNote(note.id)}
-										title={t('characterSheet.notesDelete')}
-										type="button"
-									>
-										×
-									</StyledDeleteButton>
-								</div>
-								<StyledNoteInput
-									value={note.body}
-									onChange={(e) => handleUpdateBody(note.id, e.target.value)}
-									placeholder={t('characterSheet.notesPlaceholder')}
-								/>
-							</StyledNoteItem>
-						))}
+								</StyledNoteItem>
+							);
+						})}
 					</StyledNotesList>
 				)}
 			</StyledNotesContent>

--- a/src/routes/character-sheet/components/RulebookPanel.tsx
+++ b/src/routes/character-sheet/components/RulebookPanel.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 import { AnimatePresence, motion } from 'framer-motion';
-import { theme } from '../styles/theme';
+import { media, theme } from '../styles/theme';
 // Vite bundles this PDF and gives us a hashed URL we can load into an iframe.
 // The browser's built-in PDF viewer provides search, navigation and zoom for
 // free, so we don't need to ship pdfjs-dist for this MVP.
@@ -28,7 +28,7 @@ const Panel = styled(motion.aside)`
 	display: flex;
 	flex-direction: column;
 
-	@media (max-width: 640px) {
+	${media.mobile} {
 		width: 100vw;
 		border-left: none;
 	}

--- a/src/routes/character-sheet/components/Spells.tsx
+++ b/src/routes/character-sheet/components/Spells.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
-import { Check, Pencil } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import type { SpellData } from '../../../types';
 import type { Spell } from '../../../lib/rulesdata/schemas/spell.schema';
@@ -16,7 +15,7 @@ import {
 } from '../hooks/CharacterSheetProvider';
 import { getSpellPresentation } from '../spellPresentation';
 import { logger } from '../../../lib/utils/logger';
-import DeleteButton from './shared/DeleteButton';
+import RowEditControls from './shared/RowEditControls';
 import {
 	StyledSpellsSection,
 	StyledSpellsHeader,
@@ -121,13 +120,15 @@ export interface SpellsProps {
 	readOnly?: boolean; // New prop for read-only display
 	isMobile?: boolean;
 	onSpellCast?: (spell: SpellData) => void;
+	showTitle?: boolean;
 }
 
 const Spells: React.FC<SpellsProps> = ({
 	onSpellClick: _onSpellClick,
 	readOnly = false,
 	isMobile,
-	onSpellCast
+	onSpellCast,
+	showTitle = true
 }) => {
 	const { t } = useTranslation();
 	const { addSpell, removeSpell, updateSpell, state } = useCharacterSheet();
@@ -339,7 +340,7 @@ const Spells: React.FC<SpellsProps> = ({
 	return (
 		<StyledSpellsSection $isMobile={effectiveIsMobile} data-testid="spells-section">
 			<StyledSpellsHeader $isMobile={effectiveIsMobile}>
-				<StyledSpellsTitle $isMobile={effectiveIsMobile}>Spells</StyledSpellsTitle>
+				{showTitle && <StyledSpellsTitle $isMobile={effectiveIsMobile}>Spells</StyledSpellsTitle>}
 				{!isLocked && (
 					<StyledSpellsControls $isMobile={effectiveIsMobile} data-testid="spells-controls">
 						<Link
@@ -612,23 +613,13 @@ const Spells: React.FC<SpellsProps> = ({
 											</StyledSpellActionButton>
 										)}
 										{!isLocked && (
-											<StyledSpellActionButton
-												onClick={() => toggleSpellEditing(spell.id)}
-												aria-label={isEditing ? 'Finish Editing Spell Slot' : 'Edit Spell Slot'}
-												title={isEditing ? 'Finish editing spell slot' : 'Edit spell slot'}
-												data-testid={`edit-spell-${spell.id}`}
-											>
-												{isEditing ? <Check size={14} /> : <Pencil size={14} />}
-											</StyledSpellActionButton>
-										)}
-										{!isLocked && isEditing && (
-											<DeleteButton
-												onClick={(event) => {
-													event.stopPropagation();
-													removeSpellSlot(originalIndex);
-												}}
-												title="Remove spell slot"
-												$isMobile={effectiveIsMobile}
+											<RowEditControls
+												isEditing={isEditing}
+												onToggle={() => toggleSpellEditing(spell.id)}
+												onDelete={() => removeSpellSlot(originalIndex)}
+												itemLabel="spell slot"
+												isMobile={effectiveIsMobile}
+												toggleTestId={`edit-spell-${spell.id}`}
 											/>
 										)}
 									</StyledSpellActions>

--- a/src/routes/character-sheet/components/Tooltip.tsx
+++ b/src/routes/character-sheet/components/Tooltip.tsx
@@ -33,6 +33,7 @@ const TooltipContent = styled.div<{
 	width: max-content;
 	min-width: 150px;
 
+	display: ${(props) => (props.$visible ? 'block' : 'none')};
 	opacity: ${(props) => (props.$visible ? 1 : 0)};
 	visibility: ${(props) => (props.$visible ? 'visible' : 'hidden')};
 	transition:

--- a/src/routes/character-sheet/components/new/HeroSection.tsx
+++ b/src/routes/character-sheet/components/new/HeroSection.tsx
@@ -91,18 +91,11 @@ interface HeroSectionProps {
 
 const Container = styled(motion.section)`
 	display: grid;
-	grid-template-columns: repeat(3, 1fr);
+	grid-template-columns: repeat(auto-fit, minmax(min(100%, 18rem), 1fr));
 	gap: ${theme.spacing[4]};
 	margin-bottom: ${theme.spacing[4]};
 	align-items: stretch;
-
-	@media (max-width: 1200px) {
-		grid-template-columns: 1fr 1fr;
-	}
-
-	@media (max-width: 768px) {
-		grid-template-columns: 1fr;
-	}
+	min-width: 0;
 `;
 
 // Wraps two BoxCards vertically inside a single grid column.
@@ -161,30 +154,21 @@ const ResourcesGroup = styled.div`
 // Horizontal layout for the inner pair (Mana | Stamina, Rest | Grit).
 // Each StatCard takes equal width and is allowed to shrink (min-width: 0).
 const ResourcesPairRow = styled.div`
-	display: flex;
-	flex-direction: row;
+	display: grid;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
 	gap: ${theme.spacing[3]};
 	align-items: stretch;
 
 	& > * {
-		flex: 1 1 0;
 		min-width: 0;
-	}
-
-	@media (max-width: 480px) {
-		flex-direction: column;
 	}
 `;
 
 const DefensesGrid = styled.div<{ $withMarginTop?: boolean }>`
 	display: grid;
-	grid-template-columns: repeat(3, 1fr);
+	grid-template-columns: repeat(3, minmax(0, 1fr));
 	gap: ${theme.spacing[3]};
 	${(props) => props.$withMarginTop && `margin-top: ${theme.spacing[3]};`}
-
-	@media (max-width: 1400px) {
-		grid-template-columns: 1fr;
-	}
 `;
 
 const DefenseItem = styled(motion.div)<{ $clickable?: boolean }>`

--- a/src/routes/character-sheet/components/new/StatCard.test.tsx
+++ b/src/routes/character-sheet/components/new/StatCard.test.tsx
@@ -113,6 +113,29 @@ describe('StatCard HP range', () => {
 		).toEqual(['Decrease HP', 'Increase HP', 'Decrease Temp HP', 'Increase Temp HP']);
 	});
 
+	it('renders inline content immediately after the label', () => {
+		render(
+			<StatCard
+				label="HP"
+				current={-1}
+				max={8}
+				onChange={vi.fn()}
+				afterLabel={<div data-testid="health-status">Death's Door</div>}
+				reserveAfterLabelSpace
+			/>
+		);
+
+		expect(screen.getByText('HP').nextElementSibling).toContainElement(
+			screen.getByTestId('health-status')
+		);
+	});
+
+	it('reserves the label-detail row when it has no content', () => {
+		render(<StatCard label="Mana" current={9} max={9} onChange={vi.fn()} reserveAfterLabelSpace />);
+
+		expect(screen.getByText('Mana').nextElementSibling).toBeEmptyDOMElement();
+	});
+
 	it('renders inline content immediately after the progress bar', () => {
 		render(
 			<StatCard

--- a/src/routes/character-sheet/components/new/StatCard.tsx
+++ b/src/routes/character-sheet/components/new/StatCard.tsx
@@ -76,6 +76,13 @@ const ValueContainer = styled.div`
 	min-height: 2.5rem;
 `;
 
+const ValuePair = styled.span`
+	display: grid;
+	grid-template-columns: minmax(3ch, 1fr) auto minmax(3ch, 1fr);
+	align-items: baseline;
+	column-gap: ${theme.spacing[1]};
+`;
+
 const CurrentValue = styled(motion.span)<{ $size: StatSize; $color: string }>`
 	color: ${theme.colors.text.primary};
 	font-size: ${(props) => {
@@ -94,13 +101,24 @@ const CurrentValue = styled(motion.span)<{ $size: StatSize; $color: string }>`
 	display: inline-block;
 	min-width: 3ch;
 	padding-inline: 0.1ch;
-	text-align: center;
+	text-align: right;
 	font-variant-numeric: tabular-nums;
 `;
 
-const MaxValue = styled.span<{ $size: StatSize }>`
+const MaxValue = styled.span<{ $size: StatSize; $value?: boolean }>`
 	color: ${theme.colors.text.secondary};
 	font-size: ${(props) => {
+		if (props.$value) {
+			switch (props.$size) {
+				case 'small':
+					return theme.typography.fontSize.xl;
+				case 'medium':
+					return theme.typography.fontSize['2xl'];
+				case 'large':
+					return theme.typography.fontSize['3xl'];
+			}
+		}
+
 		switch (props.$size) {
 			case 'small':
 				return theme.typography.fontSize.base;
@@ -110,7 +128,11 @@ const MaxValue = styled.span<{ $size: StatSize }>`
 				return theme.typography.fontSize.xl;
 		}
 	}};
-	font-weight: ${theme.typography.fontWeight.medium};
+	font-weight: ${(props) =>
+		props.$value ? theme.typography.fontWeight.bold : theme.typography.fontWeight.medium};
+	min-width: ${(props) => (props.$value ? '3ch' : 'auto')};
+	text-align: ${(props) => (props.$value ? 'left' : 'center')};
+	font-variant-numeric: tabular-nums;
 `;
 
 const ProgressBarContainer = styled.div`
@@ -206,11 +228,6 @@ const InlineControlGroup = styled.div`
 
 // Framed mini-stat so Temp HP remains distinct from the main HP value.
 const TempInlineGroup = styled(InlineControlGroup)`
-	background: ${theme.colors.bg.primary};
-	border: 1px solid ${TEMP_HP_COLOR};
-	border-radius: ${theme.borderRadius.md};
-	padding: ${theme.spacing[1]} ${theme.spacing[2]};
-
 	& button {
 		color: ${TEMP_HP_COLOR};
 		box-shadow: inset 0 0 0 1px ${TEMP_HP_COLOR};
@@ -326,22 +343,26 @@ export const StatCard: React.FC<StatCardProps> = ({
 						−
 					</ControlButton>
 				)}
-				<CurrentValue
-					$size={size}
-					$color={current < 0 ? NEGATIVE_HP_COLOR : colorValue}
-					key={current}
-					initial={{ scale: 1.2 }}
-					animate={{ scale: 1 }}
-					transition={{ type: 'spring', stiffness: 300, damping: 20 }}
-				>
-					{current}
-				</CurrentValue>
-				{max !== undefined && (
-					<>
-						<MaxValue $size={size}>/</MaxValue>
-						<MaxValue $size={size}>{max}</MaxValue>
-					</>
-				)}
+				<ValuePair>
+					<CurrentValue
+						$size={size}
+						$color={current < 0 ? NEGATIVE_HP_COLOR : colorValue}
+						key={current}
+						initial={{ scale: 1.2 }}
+						animate={{ scale: 1 }}
+						transition={{ type: 'spring', stiffness: 300, damping: 20 }}
+					>
+						{current}
+					</CurrentValue>
+					{max !== undefined && (
+						<>
+							<MaxValue $size={size}>/</MaxValue>
+							<MaxValue $size={size} $value>
+								{max}
+							</MaxValue>
+						</>
+					)}
+				</ValuePair>
 				{editable && onChange && (
 					<ControlButton
 						onClick={handleIncrement}
@@ -353,34 +374,6 @@ export const StatCard: React.FC<StatCardProps> = ({
 					</ControlButton>
 				)}
 			</ValueContainer>
-
-			{editable && onTempChange && temp !== undefined && (
-				<ControlsRow>
-					<TempInlineGroup>
-						<ControlButton
-							onClick={() => {
-								onTempChange(Math.max(0, temp - 1));
-							}}
-							whileHover={{ scale: 1.1 }}
-							whileTap={{ scale: 0.95 }}
-							aria-label="Decrease Temp HP"
-						>
-							−
-						</ControlButton>
-						<InlineControlLabel>Temp HP {temp}</InlineControlLabel>
-						<ControlButton
-							onClick={() => {
-								onTempChange(temp + 1);
-							}}
-							whileHover={{ scale: 1.1 }}
-							whileTap={{ scale: 0.95 }}
-							aria-label="Increase Temp HP"
-						>
-							+
-						</ControlButton>
-					</TempInlineGroup>
-				</ControlsRow>
-			)}
 
 			{showProgressBar && max !== undefined && (
 				<ProgressBarContainer data-testid="resource-progress-bar">
@@ -424,6 +417,34 @@ export const StatCard: React.FC<StatCardProps> = ({
 						/>
 					)}
 				</ProgressBarContainer>
+			)}
+
+			{editable && onTempChange && temp !== undefined && (
+				<ControlsRow>
+					<TempInlineGroup>
+						<ControlButton
+							onClick={() => {
+								onTempChange(Math.max(0, temp - 1));
+							}}
+							whileHover={{ scale: 1.1 }}
+							whileTap={{ scale: 0.95 }}
+							aria-label="Decrease Temp HP"
+						>
+							−
+						</ControlButton>
+						<InlineControlLabel>Temp HP {temp}</InlineControlLabel>
+						<ControlButton
+							onClick={() => {
+								onTempChange(temp + 1);
+							}}
+							whileHover={{ scale: 1.1 }}
+							whileTap={{ scale: 0.95 }}
+							aria-label="Increase Temp HP"
+						>
+							+
+						</ControlButton>
+					</TempInlineGroup>
+				</ControlsRow>
 			)}
 
 			{afterProgressBar}

--- a/src/routes/character-sheet/components/new/StatCard.tsx
+++ b/src/routes/character-sheet/components/new/StatCard.tsx
@@ -19,7 +19,10 @@ interface StatCardProps {
 	onTempChange?: (value: number) => void;
 	onMouseEnter?: (e: React.MouseEvent) => void;
 	onMouseLeave?: () => void;
+	afterLabel?: React.ReactNode;
+	reserveAfterLabelSpace?: boolean;
 	afterProgressBar?: React.ReactNode;
+	animateOnMount?: boolean;
 	className?: string;
 }
 
@@ -49,7 +52,7 @@ const Container = styled(motion.div)<{ $size: StatSize; $color: string }>`
 	}
 `;
 
-const Label = styled.div<{ $size: StatSize }>`
+const Label = styled.div<{ $size: StatSize; $hasDetailSpace: boolean }>`
 	color: ${theme.colors.text.secondary};
 	font-size: ${(props) => {
 		switch (props.$size) {
@@ -64,8 +67,20 @@ const Label = styled.div<{ $size: StatSize }>`
 	font-weight: ${theme.typography.fontWeight.medium};
 	text-transform: uppercase;
 	letter-spacing: 0.05em;
-	min-height: 2.5rem;
+	min-height: ${({ $hasDetailSpace }) => ($hasDetailSpace ? '1.25rem' : '2.5rem')};
 	text-align: center;
+`;
+
+const AfterLabelSlot = styled.div`
+	display: flex;
+	align-items: flex-start;
+	justify-content: center;
+	min-height: 1.5rem;
+	margin-bottom: ${theme.spacing[2]};
+
+	& > * {
+		margin-top: 0;
+	}
 `;
 
 const ValueContainer = styled.div`
@@ -283,7 +298,10 @@ export const StatCard: React.FC<StatCardProps> = ({
 	onTempChange,
 	onMouseEnter,
 	onMouseLeave,
+	afterLabel,
+	reserveAfterLabelSpace = false,
 	afterProgressBar,
+	animateOnMount = true,
 	className
 }) => {
 	const colorValue = theme.colors.resource[color];
@@ -324,13 +342,18 @@ export const StatCard: React.FC<StatCardProps> = ({
 			$size={size}
 			$color={colorValue}
 			className={className}
-			initial={{ opacity: 0, y: 20 }}
+			initial={animateOnMount ? { opacity: 0, y: 20 } : false}
 			animate={{ opacity: 1, y: 0 }}
 			transition={{ duration: 0.3 }}
 			onMouseEnter={onMouseEnter}
 			onMouseLeave={onMouseLeave}
 		>
-			<Label $size={size}>{label}</Label>
+			<Label $size={size} $hasDetailSpace={reserveAfterLabelSpace || afterLabel !== undefined}>
+				{label}
+			</Label>
+			{(reserveAfterLabelSpace || afterLabel !== undefined) && (
+				<AfterLabelSlot>{afterLabel}</AfterLabelSlot>
+			)}
 
 			<ValueContainer>
 				{editable && onChange && (
@@ -384,7 +407,7 @@ export const StatCard: React.FC<StatCardProps> = ({
 									data-testid="negative-hp-fill"
 									$color={NEGATIVE_HP_COLOR}
 									style={{ right: `${100 - zeroPositionPercent}%` }}
-									initial={{ width: 0 }}
+									initial={animateOnMount ? { width: 0 } : false}
 									animate={{ width: `${negativeFillPercent}%` }}
 									transition={{ duration: 0.25, ease: 'easeOut' }}
 								/>
@@ -401,7 +424,7 @@ export const StatCard: React.FC<StatCardProps> = ({
 						<ProgressBar
 							$color={colorValue}
 							style={{ left: `${zeroPositionPercent}%` }}
-							initial={{ width: 0 }}
+							initial={animateOnMount ? { width: 0 } : false}
 							animate={{ width: `${normalFillPercent}%` }}
 							transition={{ duration: 0.25, ease: 'easeOut' }}
 						/>
@@ -411,7 +434,7 @@ export const StatCard: React.FC<StatCardProps> = ({
 						<ProgressBar
 							$color={TEMP_HP_COLOR}
 							style={{ left: `${zeroPositionPercent + normalFillPercent}%` }}
-							initial={{ width: 0 }}
+							initial={animateOnMount ? { width: 0 } : false}
 							animate={{ width: `${tempFillPercent}%` }}
 							transition={{ duration: 0.25, ease: 'easeOut' }}
 						/>

--- a/src/routes/character-sheet/components/shared/DeleteButton.tsx
+++ b/src/routes/character-sheet/components/shared/DeleteButton.tsx
@@ -22,12 +22,12 @@ const StyledDeleteButton = styled.button<{ $isMobile?: boolean }>`
 	align-items: center;
 	justify-content: center;
 	padding: 0;
-	transition: all ${theme.transitions.fast};
+	transition: var(--delete-button-transition, all ${theme.transitions.fast});
 
 	&:hover {
 		background-color: ${theme.colors.accent.danger};
 		color: ${theme.colors.text.inverse};
-		transform: scale(1.1);
+		transform: var(--delete-button-hover-transform, scale(1.1));
 	}
 
 	@media (max-width: 768px) {

--- a/src/routes/character-sheet/components/shared/RowEditControls.test.tsx
+++ b/src/routes/character-sheet/components/shared/RowEditControls.test.tsx
@@ -1,0 +1,32 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import RowEditControls from './RowEditControls';
+
+afterEach(cleanup);
+
+describe('RowEditControls', () => {
+	it('shows edit without delete until the row enters edit mode', () => {
+		const onToggle = vi.fn();
+		const onDelete = vi.fn();
+		const { rerender } = render(
+			<RowEditControls
+				isEditing={false}
+				onToggle={onToggle}
+				onDelete={onDelete}
+				itemLabel="spell slot"
+			/>
+		);
+
+		fireEvent.click(screen.getByRole('button', { name: 'Edit spell slot' }));
+		expect(onToggle).toHaveBeenCalledOnce();
+		expect(screen.queryByTitle('Delete spell slot')).not.toBeInTheDocument();
+
+		rerender(
+			<RowEditControls isEditing onToggle={onToggle} onDelete={onDelete} itemLabel="spell slot" />
+		);
+
+		expect(screen.getByRole('button', { name: 'Finish editing spell slot' })).toBeInTheDocument();
+		fireEvent.click(screen.getByTitle('Delete spell slot'));
+		expect(onDelete).toHaveBeenCalledOnce();
+	});
+});

--- a/src/routes/character-sheet/components/shared/RowEditControls.tsx
+++ b/src/routes/character-sheet/components/shared/RowEditControls.tsx
@@ -1,0 +1,80 @@
+import { Check, Pencil } from 'lucide-react';
+import styled from 'styled-components';
+import DeleteButton from './DeleteButton';
+import { theme } from '../../styles/theme';
+
+const Actions = styled.div`
+	display: flex;
+	align-items: center;
+	justify-content: flex-end;
+	gap: ${theme.spacing[1]};
+`;
+
+const EditButton = styled.button`
+	width: 24px;
+	height: 24px;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	padding: 0;
+	border: 1px solid ${theme.colors.border.default};
+	border-radius: ${theme.borderRadius.sm};
+	background: transparent;
+	color: ${theme.colors.text.secondary};
+	cursor: pointer;
+
+	&:hover,
+	&:focus-visible {
+		border-color: ${theme.colors.accent.primary};
+		color: ${theme.colors.accent.primary};
+		background: ${theme.colors.bg.elevated};
+		outline: none;
+	}
+`;
+
+interface RowEditControlsProps {
+	isEditing: boolean;
+	onToggle: () => void;
+	onDelete: () => void;
+	itemLabel: string;
+	isMobile?: boolean;
+	toggleTestId?: string;
+}
+
+export default function RowEditControls({
+	isEditing,
+	onToggle,
+	onDelete,
+	itemLabel,
+	isMobile,
+	toggleTestId
+}: RowEditControlsProps) {
+	const action = isEditing ? 'Finish editing' : 'Edit';
+
+	return (
+		<Actions>
+			<EditButton
+				type="button"
+				onClick={(event) => {
+					event.stopPropagation();
+					onToggle();
+				}}
+				aria-label={`${action} ${itemLabel}`}
+				title={`${action} ${itemLabel}`}
+				data-testid={toggleTestId}
+			>
+				{isEditing ? <Check size={14} /> : <Pencil size={14} />}
+			</EditButton>
+			{isEditing && (
+				<DeleteButton
+					onClick={(event) => {
+						event.stopPropagation();
+						onDelete();
+					}}
+					title={`Delete ${itemLabel}`}
+					$isMobile={isMobile}
+				/>
+			)}
+		</Actions>
+	);
+}

--- a/src/routes/character-sheet/hooks/useBreakpoint.test.tsx
+++ b/src/routes/character-sheet/hooks/useBreakpoint.test.tsx
@@ -1,0 +1,48 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { breakpoints } from '../../../styles/responsive';
+import { useBreakpoint } from './useBreakpoint';
+
+function setViewportWidth(width: number) {
+	Object.defineProperty(window, 'innerWidth', {
+		configurable: true,
+		value: width
+	});
+	window.dispatchEvent(new Event('resize'));
+}
+
+describe('useBreakpoint', () => {
+	afterEach(() => {
+		setViewportWidth(1024);
+	});
+
+	it('defines exactly two shared breakpoint values', () => {
+		expect(breakpoints).toEqual({
+			tablet: 768,
+			desktop: 1200
+		});
+	});
+
+	it.each([
+		[767, 'mobile'],
+		[768, 'tablet'],
+		[1199, 'tablet'],
+		[1200, 'desktop']
+	] as const)('maps %ipx to %s', (width, expected) => {
+		setViewportWidth(width);
+		const { result } = renderHook(() => useBreakpoint());
+
+		expect(result.current).toBe(expected);
+	});
+
+	it('updates when the viewport crosses a breakpoint', () => {
+		setViewportWidth(767);
+		const { result } = renderHook(() => useBreakpoint());
+
+		act(() => setViewportWidth(768));
+		expect(result.current).toBe('tablet');
+
+		act(() => setViewportWidth(1200));
+		expect(result.current).toBe('desktop');
+	});
+});

--- a/src/routes/character-sheet/hooks/useBreakpoint.ts
+++ b/src/routes/character-sheet/hooks/useBreakpoint.ts
@@ -2,7 +2,7 @@
  * useBreakpoint Hook
  *
  * Detects current screen size breakpoint for responsive behavior.
- * Returns: 'mobile' | 'tablet' | 'desktop' | 'wide'
+ * Returns: 'mobile' | 'tablet' | 'desktop'
  *
  * Usage:
  * const breakpoint = useBreakpoint();
@@ -12,15 +12,14 @@
 import { useState, useEffect } from 'react';
 import { theme } from '../styles/theme';
 
-export type Breakpoint = 'mobile' | 'tablet' | 'desktop' | 'wide';
+export type Breakpoint = 'mobile' | 'tablet' | 'desktop';
 
 export const useBreakpoint = (): Breakpoint => {
 	// Initialize with SSR-safe approach
 	const getBreakpoint = (width: number): Breakpoint => {
-		if (width <= theme.breakpoints.mobile) return 'mobile';
-		if (width <= theme.breakpoints.tablet) return 'tablet';
-		if (width <= theme.breakpoints.desktop) return 'desktop';
-		return 'wide';
+		if (width < theme.breakpoints.tablet) return 'mobile';
+		if (width < theme.breakpoints.desktop) return 'tablet';
+		return 'desktop';
 	};
 
 	const [breakpoint, setBreakpoint] = useState<Breakpoint>(() => {
@@ -51,10 +50,7 @@ export const useBreakpoint = (): Breakpoint => {
 // Convenience hooks for common checks
 export const useIsMobile = () => useBreakpoint() === 'mobile';
 export const useIsTablet = () => useBreakpoint() === 'tablet';
-export const useIsDesktop = () => {
-	const bp = useBreakpoint();
-	return bp === 'desktop' || bp === 'wide';
-};
+export const useIsDesktop = () => useBreakpoint() === 'desktop';
 export const useIsMobileOrTablet = () => {
 	const bp = useBreakpoint();
 	return bp === 'mobile' || bp === 'tablet';

--- a/src/routes/character-sheet/naturalWeaponAttack.test.ts
+++ b/src/routes/character-sheet/naturalWeaponAttack.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import {
+	NATURAL_WEAPON_ATTACK_ID,
+	getNaturalWeaponAttack,
+	isNaturalWeaponAttack
+} from './naturalWeaponAttack';
+
+describe('getNaturalWeaponAttack', () => {
+	it('derives an unarmed strike from the Beastborn Natural Weapon trait', () => {
+		const attack = getNaturalWeaponAttack(['beastborn_natural_weapon']);
+
+		expect(attack).toMatchObject({
+			id: NATURAL_WEAPON_ATTACK_ID,
+			weaponName: 'Unarmed Strike',
+			name: 'Natural Weapon (Unarmed Strike)',
+			damage: '1 B/P/S',
+			damageType: 'bludgeoning/piercing/slashing'
+		});
+		expect(isNaturalWeaponAttack(attack!)).toBe(true);
+	});
+
+	it('supports legacy JSON trait storage', () => {
+		expect(getNaturalWeaponAttack('["beastborn_natural_weapon"]')).not.toBeNull();
+	});
+
+	it('does not add an attack without the trait', () => {
+		expect(getNaturalWeaponAttack(['beastborn_full_flight'])).toBeNull();
+	});
+});

--- a/src/routes/character-sheet/naturalWeaponAttack.ts
+++ b/src/routes/character-sheet/naturalWeaponAttack.ts
@@ -1,0 +1,41 @@
+import type { AttackData } from '../../types';
+
+export const NATURAL_WEAPON_ATTACK_ID = 'derived_beastborn_natural_weapon';
+
+function normalizeTraitIds(selectedTraitIds: unknown): string[] {
+	if (Array.isArray(selectedTraitIds)) {
+		return selectedTraitIds.filter((traitId): traitId is string => typeof traitId === 'string');
+	}
+
+	if (typeof selectedTraitIds !== 'string') return [];
+
+	try {
+		const parsed = JSON.parse(selectedTraitIds);
+		return Array.isArray(parsed)
+			? parsed.filter((traitId): traitId is string => typeof traitId === 'string')
+			: [];
+	} catch {
+		return [];
+	}
+}
+
+export function getNaturalWeaponAttack(selectedTraitIds: unknown): AttackData | null {
+	if (!normalizeTraitIds(selectedTraitIds).includes('beastborn_natural_weapon')) return null;
+
+	return {
+		id: NATURAL_WEAPON_ATTACK_ID,
+		weaponName: 'Unarmed Strike',
+		name: 'Natural Weapon (Unarmed Strike)',
+		attackBonus: 0,
+		damage: '1 B/P/S',
+		damageType: 'bludgeoning/piercing/slashing',
+		critRange: '20',
+		critDamage: '1 B/P/S',
+		brutalDamage: '3 B/P/S',
+		heavyHitEffect: ''
+	};
+}
+
+export function isNaturalWeaponAttack(attack: AttackData): boolean {
+	return attack.id === NATURAL_WEAPON_ATTACK_ID;
+}

--- a/src/routes/character-sheet/styles/Attacks.ts
+++ b/src/routes/character-sheet/styles/Attacks.ts
@@ -58,9 +58,12 @@ export const StyledAttacksContainer = styled.div<MobileStyledProps>`
 	}
 `;
 
-export const StyledAttacksHeaderRow = styled.div<MobileStyledProps>`
+export const StyledAttacksHeaderRow = styled.div<
+	MobileStyledProps & { $explicitEditMode?: boolean }
+>`
 	display: grid;
-	grid-template-columns: 0.5fr 2fr 1fr 1fr 1fr 0.7fr 0.8fr;
+	grid-template-columns: ${({ $explicitEditMode }) =>
+		$explicitEditMode ? '2fr 1fr 1fr 1fr 0.7fr 0.5fr 0.8fr' : '0.5fr 2fr 1fr 1fr 1fr 0.7fr 0.8fr'};
 	gap: ${theme.spacing[3]};
 	margin-bottom: ${theme.spacing[3]};
 	border-bottom: 1px solid ${theme.colors.border.default};
@@ -68,13 +71,14 @@ export const StyledAttacksHeaderRow = styled.div<MobileStyledProps>`
 	align-items: center;
 
 	@media (max-width: 768px) {
-		grid-template-columns: 25px 1fr 45px 40px;
+		grid-template-columns: ${({ $explicitEditMode }) =>
+			$explicitEditMode ? '1fr 45px 40px 52px' : '25px 1fr 45px 40px'};
 		gap: 0.2rem;
 		font-size: 0.7rem;
 
-		& > *:nth-child(4),
-		& > *:nth-child(5),
-		& > *:nth-child(7) {
+		& > *:nth-child(${({ $explicitEditMode }) => ($explicitEditMode ? 3 : 4)}),
+		& > *:nth-child(${({ $explicitEditMode }) => ($explicitEditMode ? 4 : 5)}),
+		& > *:nth-child(${({ $explicitEditMode }) => ($explicitEditMode ? 6 : 7)}) {
 			display: none;
 		}
 	}
@@ -91,11 +95,6 @@ export const StyledHeaderColumn = styled.span<{ $align?: string; $isMobile?: boo
 
 	@media (max-width: 768px) {
 		font-size: 0.7rem;
-		&:nth-child(4),
-		&:nth-child(5),
-		&:nth-child(7) {
-			display: none;
-		}
 	}
 `;
 
@@ -106,9 +105,10 @@ export const StyledEmptyState = styled.div<MobileStyledProps>`
 	color: ${theme.colors.text.muted};
 `;
 
-export const StyledAttackRow = styled.div<MobileStyledProps>`
+export const StyledAttackRow = styled.div<MobileStyledProps & { $explicitEditMode?: boolean }>`
 	display: grid;
-	grid-template-columns: 0.5fr 2fr 1fr 1fr 1fr 0.7fr 0.8fr;
+	grid-template-columns: ${({ $explicitEditMode }) =>
+		$explicitEditMode ? '2fr 1fr 1fr 1fr 0.7fr 0.5fr 0.8fr' : '0.5fr 2fr 1fr 1fr 1fr 0.7fr 0.8fr'};
 	gap: ${theme.spacing[3]};
 	margin-bottom: ${theme.spacing[3]};
 	align-items: center;
@@ -121,13 +121,14 @@ export const StyledAttackRow = styled.div<MobileStyledProps>`
 	}
 
 	@media (max-width: 768px) {
-		grid-template-columns: 25px 1fr 45px 40px;
+		grid-template-columns: ${({ $explicitEditMode }) =>
+			$explicitEditMode ? '1fr 45px 40px 52px' : '25px 1fr 45px 40px'};
 		gap: 0.2rem;
 		font-size: 0.7rem;
 
-		& > *:nth-child(4),
-		& > *:nth-child(5),
-		& > *:nth-child(7) {
+		& > *:nth-child(${({ $explicitEditMode }) => ($explicitEditMode ? 3 : 4)}),
+		& > *:nth-child(${({ $explicitEditMode }) => ($explicitEditMode ? 4 : 5)}),
+		& > *:nth-child(${({ $explicitEditMode }) => ($explicitEditMode ? 6 : 7)}) {
 			display: none;
 		}
 	}
@@ -177,6 +178,54 @@ export const StyledWeaponSelect = styled.select<MobileStyledProps>`
 	@media (max-width: 768px) {
 		font-size: 0.6rem;
 		padding: 0.1rem;
+	}
+`;
+
+export const StyledWeaponName = styled.div`
+	min-width: 0;
+	overflow: hidden;
+	color: ${theme.colors.text.primary};
+	font-weight: ${theme.typography.fontWeight.semibold};
+	text-overflow: ellipsis;
+	white-space: nowrap;
+`;
+
+export const StyledAttackIdentity = styled.div`
+	display: flex;
+	min-width: 0;
+	flex-direction: column;
+	gap: ${theme.spacing[1]};
+`;
+
+export const StyledAttackProperties = styled.div`
+	display: flex;
+	flex-wrap: wrap;
+	gap: ${theme.spacing[1]};
+`;
+
+export const StyledAttackProperty = styled.span`
+	width: fit-content;
+	padding: 1px ${theme.spacing[2]};
+	border: 1px solid ${theme.colors.border.default};
+	border-radius: ${theme.borderRadius.sm};
+	color: ${theme.colors.accent.primary};
+	background: ${theme.colors.bg.tertiary};
+	font-size: ${theme.typography.fontSize.xs};
+	font-weight: ${theme.typography.fontWeight.semibold};
+	line-height: ${theme.typography.lineHeight.tight};
+`;
+
+export const StyledAttackTraitNotes = styled.div`
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	color: ${theme.colors.text.muted};
+	font-size: ${theme.typography.fontSize.xs};
+	line-height: ${theme.typography.lineHeight.tight};
+
+	strong {
+		color: ${theme.colors.text.secondary};
+		font-weight: ${theme.typography.fontWeight.semibold};
 	}
 `;
 

--- a/src/routes/character-sheet/styles/Death.ts
+++ b/src/routes/character-sheet/styles/Death.ts
@@ -75,6 +75,7 @@ export const StyledHealthStatusTooltip = styled.div`
 		z-index: 1000;
 		margin-bottom: 5px;
 		box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+		display: none;
 		opacity: 0;
 		visibility: hidden;
 		transition:
@@ -85,6 +86,7 @@ export const StyledHealthStatusTooltip = styled.div`
 	}
 
 	&:hover::after {
+		display: block;
 		opacity: 1;
 		visibility: visible;
 	}

--- a/src/routes/character-sheet/styles/DiceRoller.ts
+++ b/src/routes/character-sheet/styles/DiceRoller.ts
@@ -24,9 +24,9 @@ const emberFloat = keyframes`
 export const StyledDiceRollerContainer = styled.div<{ $isExpanded: boolean }>`
 	position: fixed;
 	bottom: 1rem;
-	right: 1rem;
-	width: ${(props) => (props.$isExpanded ? '380px' : '60px')};
-	height: ${(props) => (props.$isExpanded ? 'auto' : '60px')};
+	right: ${(props) => (props.$isExpanded ? '1rem' : '0')};
+	width: ${(props) => (props.$isExpanded ? '380px' : '24px')};
+	height: ${(props) => (props.$isExpanded ? 'auto' : '48px')};
 	background: linear-gradient(135deg, rgba(26, 27, 38, 0.85), rgba(36, 40, 59, 0.9));
 	border: 2px solid var(--crystal-primary-40);
 	border-radius: 12px;
@@ -59,9 +59,9 @@ export const StyledDiceRollerContainer = styled.div<{ $isExpanded: boolean }>`
 
 	@media (max-width: 768px) {
 		bottom: 4.5rem; /* Give 10-20px clearance above mobile nav */
-		right: 0.5rem;
-		width: ${(props) => (props.$isExpanded ? '260px' : '50px')};
-		height: ${(props) => (props.$isExpanded ? 'auto' : '50px')};
+		right: ${(props) => (props.$isExpanded ? '0.5rem' : '0')};
+		width: ${(props) => (props.$isExpanded ? '260px' : '24px')};
+		height: ${(props) => (props.$isExpanded ? 'auto' : '42px')};
 		z-index: 999; /* Below mobile nav to prevent conflicts */
 	}
 `;
@@ -75,9 +75,9 @@ export const StyledCollapseButton = styled.button<{ $isExpanded: boolean }>`
 	height: ${(props) => (props.$isExpanded ? '30px' : '100%')};
 	background: linear-gradient(135deg, var(--crystal-primary-30), var(--crystal-secondary-50));
 	border: 2px solid var(--crystal-primary-60);
-	border-radius: ${(props) => (props.$isExpanded ? '6px' : '12px')};
+	border-radius: ${(props) => (props.$isExpanded ? '6px' : '10px 0 0 10px')};
 	color: var(--crystal-primary-light);
-	font-size: ${(props) => (props.$isExpanded ? '1rem' : '1.5rem')};
+	font-size: ${(props) => (props.$isExpanded ? '1rem' : '1rem')};
 	cursor: pointer;
 	display: flex;
 	align-items: center;

--- a/src/routes/character-sheet/styles/Exhaustion.ts
+++ b/src/routes/character-sheet/styles/Exhaustion.ts
@@ -67,6 +67,7 @@ export const StyledExhaustionTooltip = styled.div`
 	z-index: 1000;
 	margin-bottom: 5px;
 	box-shadow: 0 2px 8px var(--black-30);
+	display: none;
 	opacity: 0;
 	visibility: hidden;
 	transition:
@@ -84,6 +85,7 @@ export const StyledExhaustionTooltip = styled.div`
 	}
 
 	${StyledExhaustionLevel}:hover & {
+		display: block;
 		opacity: 1;
 		visibility: visible;
 	}

--- a/src/routes/character-sheet/styles/FeaturePopup.ts
+++ b/src/routes/character-sheet/styles/FeaturePopup.ts
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { theme } from './theme';
+import { media, theme } from './theme';
 
 export const StyledFeaturePopupOverlay = styled.div`
 	position: fixed;
@@ -26,8 +26,8 @@ export const StyledFeaturePopupContent = styled.div`
 	box-shadow: ${theme.shadows.xl};
 	box-sizing: border-box;
 
-	@media (max-width: 768px) {
-		width: calc(100vw - 10rem);
+	${media.mobile} {
+		width: calc(100vw - ${theme.spacing[8]});
 		margin: 5rem ${theme.spacing[4]} ${theme.spacing[4]} ${theme.spacing[4]};
 		padding: ${theme.spacing[6]};
 	}
@@ -42,7 +42,7 @@ export const StyledFeaturePopupHeader = styled.div`
 	padding-bottom: ${theme.spacing[4]};
 
 	/* Mobile responsive styling */
-	@media (max-width: 768px) {
+	${media.mobile} {
 		margin-bottom: ${theme.spacing[4]};
 		padding-bottom: ${theme.spacing[3]};
 		align-items: flex-start;
@@ -59,14 +59,10 @@ export const StyledFeaturePopupTitle = styled.h2`
 	word-wrap: break-word;
 
 	/* Mobile responsive styling */
-	@media (max-width: 768px) {
-		font-size: ${theme.typography.fontSize.xl};
+	${media.mobile} {
+		font-size: clamp(${theme.typography.fontSize.lg}, 5vw, ${theme.typography.fontSize.xl});
 		line-height: ${theme.typography.lineHeight.tight};
 		margin-right: ${theme.spacing[2]};
-	}
-
-	@media (max-width: 480px) {
-		font-size: ${theme.typography.fontSize.lg};
 	}
 `;
 
@@ -90,7 +86,7 @@ export const StyledFeaturePopupClose = styled.button`
 	}
 
 	/* Mobile responsive styling */
-	@media (max-width: 768px) {
+	${media.mobile} {
 		width: 36px;
 		height: 36px;
 		font-size: ${theme.typography.fontSize['2xl']};
@@ -106,14 +102,9 @@ export const StyledFeaturePopupDescription = styled.div`
 	overflow-wrap: break-word;
 
 	/* Mobile responsive styling */
-	@media (max-width: 768px) {
-		font-size: ${theme.typography.fontSize.sm};
+	${media.mobile} {
+		font-size: clamp(${theme.typography.fontSize.xs}, 3.5vw, ${theme.typography.fontSize.sm});
 		line-height: ${theme.typography.lineHeight.normal};
-	}
-
-	@media (max-width: 480px) {
-		font-size: ${theme.typography.fontSize.xs};
-		line-height: ${theme.typography.lineHeight.tight};
 	}
 `;
 

--- a/src/routes/character-sheet/styles/Inventory.ts
+++ b/src/routes/character-sheet/styles/Inventory.ts
@@ -49,9 +49,12 @@ export const StyledInventoryContainer = styled.div<MobileStyledProps>`
 	color: ${theme.colors.text.primary};
 `;
 
-export const StyledInventoryHeaderRow = styled.div`
+export const StyledInventoryHeaderRow = styled.div<{ $explicitEditMode?: boolean }>`
 	display: grid;
-	grid-template-columns: 30px 48px 100px 2fr 60px 30px 70px;
+	grid-template-columns: ${({ $explicitEditMode }) =>
+		$explicitEditMode
+			? '48px 100px 2fr 60px 30px 70px 56px'
+			: '30px 48px 100px 2fr 60px 30px 70px'};
 	gap: ${theme.spacing[2]};
 	margin-bottom: ${theme.spacing[2]};
 	border-bottom: 1px solid ${theme.colors.border.default};
@@ -66,12 +69,24 @@ export const StyledInventoryHeaderColumn = styled.span.withConfig({
 	text-align: ${(props) => props.align || 'left'};
 `;
 
-export const StyledInventoryRow = styled.div`
+export const StyledInventoryRow = styled.div<{ $explicitEditMode?: boolean }>`
 	display: grid;
-	grid-template-columns: 30px 48px 100px 2fr 60px 30px 70px;
+	grid-template-columns: ${({ $explicitEditMode }) =>
+		$explicitEditMode
+			? '48px 100px 2fr 60px 30px 70px 56px'
+			: '30px 48px 100px 2fr 60px 30px 70px'};
 	gap: ${theme.spacing[2]};
 	margin-bottom: ${theme.spacing[2]};
 	align-items: center;
+`;
+
+export const StyledInventoryValue = styled.div<{ $centered?: boolean }>`
+	min-width: 0;
+	overflow: hidden;
+	color: ${theme.colors.text.primary};
+	text-align: ${({ $centered }) => ($centered ? 'center' : 'left')};
+	text-overflow: ellipsis;
+	white-space: nowrap;
 `;
 
 export const StyledRemoveItemButton = styled.button`

--- a/src/routes/character-sheet/styles/Maneuvers.styles.ts
+++ b/src/routes/character-sheet/styles/Maneuvers.styles.ts
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { theme } from './theme';
+import { media, theme } from './theme';
 
 interface MobileStyledProps {
 	$isMobile?: boolean;
@@ -11,6 +11,11 @@ export const StyledManeuversSection = styled.div<MobileStyledProps>`
 	border: 1px solid ${theme.colors.border.default};
 	border-radius: ${theme.borderRadius.lg};
 	padding: ${theme.spacing[4]};
+	min-width: 0;
+
+	${media.mobile} {
+		padding: ${theme.spacing[3]};
+	}
 `;
 
 export const StyledManeuversHeader = styled.div<MobileStyledProps>`
@@ -20,6 +25,16 @@ export const StyledManeuversHeader = styled.div<MobileStyledProps>`
 	margin-bottom: ${theme.spacing[4]};
 	padding-bottom: ${theme.spacing[3]};
 	border-bottom: 1px solid ${theme.colors.border.default};
+
+	@container sheet-tabs (max-width: 56rem) {
+		align-items: flex-start;
+		flex-wrap: wrap;
+		gap: ${theme.spacing[3]};
+	}
+
+	${media.mobile} {
+		flex-direction: column;
+	}
 `;
 
 export const StyledManeuversTitle = styled.h3<MobileStyledProps>`
@@ -35,6 +50,13 @@ export const StyledManeuversControls = styled.div<MobileStyledProps>`
 	display: flex;
 	gap: 0.5rem;
 	align-items: center;
+	min-width: 0;
+
+	@container sheet-tabs (max-width: 56rem) {
+		flex: 1 1 100%;
+		flex-wrap: wrap;
+		width: 100%;
+	}
 `;
 
 export const StyledAddManeuverButton = styled.button<MobileStyledProps>`
@@ -75,6 +97,10 @@ export const StyledManeuversHeaderRow = styled.div<MobileStyledProps>`
 	color: ${theme.colors.text.secondary};
 	text-transform: uppercase;
 	letter-spacing: 0.05em;
+
+	@container sheet-tabs (max-width: 56rem) {
+		display: none;
+	}
 `;
 
 export const StyledManeuverHeaderColumn = styled.div<MobileStyledProps>`
@@ -105,10 +131,40 @@ export const StyledManeuverRow = styled.div<MobileStyledProps>`
 	min-height: 48px;
 	cursor: pointer;
 	transition: all ${theme.transitions.fast};
+	min-width: 0;
 
 	&:hover {
 		background: ${theme.colors.bg.elevated};
 		border-color: ${theme.colors.accent.primary};
+	}
+
+	@container sheet-tabs (max-width: 56rem) {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		gap: ${theme.spacing[3]};
+
+		& > :first-child,
+		& > :last-child {
+			grid-column: 1 / -1;
+		}
+
+		& > :nth-child(n + 2):nth-child(-n + 4)::before {
+			display: block;
+			margin-bottom: ${theme.spacing[1]};
+			color: ${theme.colors.text.muted};
+			font-size: ${theme.typography.fontSize.xs};
+			font-weight: ${theme.typography.fontWeight.semibold};
+			text-transform: uppercase;
+		}
+
+		& > :nth-child(2)::before {
+			content: 'Type';
+		}
+		& > :nth-child(3)::before {
+			content: 'Cost';
+		}
+		& > :nth-child(4)::before {
+			content: 'Timing';
+		}
 	}
 `;
 
@@ -117,6 +173,10 @@ export const StyledManeuverActions = styled.div`
 	align-items: center;
 	justify-content: flex-end;
 	gap: ${theme.spacing[1]};
+
+	@container sheet-tabs (max-width: 56rem) {
+		justify-content: flex-end;
+	}
 `;
 
 export const StyledManeuverActionButton = styled.button`
@@ -150,6 +210,15 @@ export const StyledManeuverCell = styled.div<MobileStyledProps>`
 	text-align: center;
 	word-wrap: break-word;
 	line-height: ${theme.typography.lineHeight.tight};
+	min-width: 0;
+	overflow-wrap: anywhere;
+
+	@container sheet-tabs (max-width: 56rem) {
+		flex-direction: column;
+		align-items: flex-start;
+		justify-content: flex-start;
+		text-align: left;
+	}
 `;
 
 export const StyledManeuverNameCell = styled(StyledManeuverCell)<MobileStyledProps>`
@@ -190,6 +259,8 @@ export const StyledManeuverTypeFilter = styled.select<MobileStyledProps>`
 	background: ${theme.colors.bg.primary};
 	color: ${theme.colors.text.primary};
 	min-width: 120px;
+	max-width: 100%;
+	flex: 1 1 10rem;
 	transition: all ${theme.transitions.fast};
 
 	&:focus {
@@ -268,6 +339,8 @@ export const StyledManeuverDescriptionContainer = styled.div<MobileStyledProps>`
 	border-top: none;
 	border-radius: 0 0 ${theme.borderRadius.md} ${theme.borderRadius.md};
 	margin-bottom: ${theme.spacing[2]};
+	min-width: 0;
+	overflow-wrap: anywhere;
 `;
 
 export const StyledManeuverDescriptionHeader = styled.div<MobileStyledProps>`

--- a/src/routes/character-sheet/styles/Skills.ts
+++ b/src/routes/character-sheet/styles/Skills.ts
@@ -33,7 +33,7 @@ export const StyledDot = styled.div<{ $filled: boolean; $isMobile?: boolean }>`
 	border: 1px solid ${(props) => (props.$isMobile ? 'var(--mobile-border)' : '#414868')};
 	background: ${(props) => {
 		if (props.$filled) {
-			return '#7DCFFF'; /* Tokyo Night blue for all breakpoints */
+			return 'var(--mastery-dot-color, #7DCFFF)';
 		} else {
 			return props.$isMobile ? 'var(--mobile-bg-secondary)' : '#1A1B26';
 		}

--- a/src/routes/character-sheet/styles/Spells.ts
+++ b/src/routes/character-sheet/styles/Spells.ts
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { theme } from './theme';
+import { media, theme } from './theme';
 
 interface MobileStyledProps {
 	$isMobile?: boolean;
@@ -11,6 +11,11 @@ export const StyledSpellsSection = styled.div<MobileStyledProps>`
 	border: 1px solid ${theme.colors.border.default};
 	border-radius: ${theme.borderRadius.lg};
 	padding: ${theme.spacing[4]};
+	min-width: 0;
+
+	${media.mobile} {
+		padding: ${theme.spacing[3]};
+	}
 `;
 
 export const StyledSpellsHeader = styled.div<MobileStyledProps>`
@@ -20,6 +25,16 @@ export const StyledSpellsHeader = styled.div<MobileStyledProps>`
 	margin-bottom: ${theme.spacing[4]};
 	padding-bottom: ${theme.spacing[2]};
 	border-bottom: 1px solid ${theme.colors.border.default};
+
+	@container sheet-tabs (max-width: 56rem) {
+		align-items: flex-start;
+		flex-wrap: wrap;
+		gap: ${theme.spacing[3]};
+	}
+
+	${media.mobile} {
+		flex-direction: column;
+	}
 `;
 
 export const StyledSpellsTitle = styled.h3<MobileStyledProps>`
@@ -36,6 +51,13 @@ export const StyledSpellsControls = styled.div<MobileStyledProps>`
 	display: flex;
 	gap: ${theme.spacing[2]};
 	align-items: center;
+	min-width: 0;
+
+	@container sheet-tabs (max-width: 56rem) {
+		flex: 1 1 100%;
+		flex-wrap: wrap;
+		width: 100%;
+	}
 `;
 
 export const StyledAddSpellButton = styled.button<MobileStyledProps>`
@@ -73,6 +95,10 @@ export const StyledSpellsHeaderRow = styled.div<MobileStyledProps>`
 	font-weight: ${theme.typography.fontWeight.bold};
 	font-size: ${theme.typography.fontSize.sm};
 	color: ${theme.colors.accent.primary};
+
+	@container sheet-tabs (max-width: 56rem) {
+		display: none;
+	}
 `;
 
 export const StyledHeaderColumn = styled.div<MobileStyledProps>`
@@ -100,10 +126,47 @@ export const StyledSpellRow = styled.div<MobileStyledProps>`
 	align-items: center;
 	cursor: pointer;
 	transition: all ${theme.transitions.fast};
+	min-width: 0;
 
 	&:hover {
 		background: ${theme.colors.bg.elevated};
 		border-color: ${theme.colors.accent.primary};
+	}
+
+	@container sheet-tabs (max-width: 56rem) {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		gap: ${theme.spacing[3]};
+		padding: ${theme.spacing[3]};
+
+		& > :first-child,
+		& > :last-child {
+			grid-column: 1 / -1;
+		}
+
+		& > :nth-child(n + 2):nth-child(-n + 6)::before {
+			display: block;
+			margin-bottom: ${theme.spacing[1]};
+			color: ${theme.colors.text.muted};
+			font-size: ${theme.typography.fontSize.xs};
+			font-weight: ${theme.typography.fontWeight.semibold};
+			text-transform: uppercase;
+		}
+
+		& > :nth-child(2)::before {
+			content: 'School';
+		}
+		& > :nth-child(3)::before {
+			content: 'Duration';
+		}
+		& > :nth-child(4)::before {
+			content: 'AP';
+		}
+		& > :nth-child(5)::before {
+			content: 'MP';
+		}
+		& > :nth-child(6)::before {
+			content: 'Range';
+		}
 	}
 `;
 
@@ -112,6 +175,10 @@ export const StyledSpellActions = styled.div`
 	align-items: center;
 	justify-content: flex-end;
 	gap: ${theme.spacing[1]};
+
+	@container sheet-tabs (max-width: 56rem) {
+		justify-content: flex-end;
+	}
 `;
 
 export const StyledSpellActionButton = styled.button`
@@ -167,6 +234,7 @@ export const StyledSpellSelect = styled.select<MobileStyledProps>`
 	background: ${theme.colors.bg.primary};
 	color: ${theme.colors.text.primary};
 	transition: border-color 0.2s;
+	min-width: 0;
 
 	&:focus {
 		outline: none;
@@ -187,6 +255,8 @@ export const StyledSchoolFilter = styled.select<MobileStyledProps>`
 	background: ${theme.colors.bg.primary};
 	color: ${theme.colors.text.primary};
 	transition: border-color 0.2s;
+	min-width: min(10rem, 100%);
+	flex: 1 1 10rem;
 
 	&:focus {
 		outline: none;
@@ -206,6 +276,15 @@ export const StyledSpellCell = styled.div<MobileStyledProps>`
 	align-items: center;
 	justify-content: center;
 	text-align: center;
+	min-width: 0;
+	overflow-wrap: anywhere;
+
+	@container sheet-tabs (max-width: 56rem) {
+		flex-direction: column;
+		align-items: flex-start;
+		justify-content: flex-start;
+		text-align: left;
+	}
 `;
 
 interface BoldSpellCellProps extends MobileStyledProps {
@@ -268,6 +347,11 @@ export const StyledFilterLabel = styled.label<MobileStyledProps>`
 	font-size: ${theme.typography.fontSize.sm};
 	color: ${theme.colors.text.secondary};
 	margin-right: ${theme.spacing[2]};
+
+	@container sheet-tabs (max-width: 56rem) {
+		flex: 0 0 100%;
+		margin-right: 0;
+	}
 `;
 
 export const StyledSpellDescriptionContainer = styled.div<MobileStyledProps>`
@@ -278,6 +362,8 @@ export const StyledSpellDescriptionContainer = styled.div<MobileStyledProps>`
 	border-top: none;
 	border-radius: 0 0 ${theme.borderRadius.md} ${theme.borderRadius.md};
 	margin-top: -${theme.spacing[1]};
+	min-width: 0;
+	overflow-wrap: anywhere;
 `;
 
 export const StyledSpellDescriptionHeader = styled.div<MobileStyledProps>`

--- a/src/routes/character-sheet/styles/theme.ts
+++ b/src/routes/character-sheet/styles/theme.ts
@@ -3,6 +3,8 @@
  * Modern, dark color palette with excellent contrast
  */
 
+import { breakpoints, media } from '../../../styles/responsive';
+
 export const theme = {
 	// Background colors
 	colors: {
@@ -216,35 +218,10 @@ export const theme = {
 		tooltip: 1600
 	},
 
-	// Responsive Breakpoints (px values)
-	breakpoints: {
-		mobile: 768,
-		tablet: 1024,
-		desktop: 1440,
-		wide: 1920
-	}
+	// Two shared responsive thresholds: compact -> tablet -> desktop.
+	breakpoints
 } as const;
 
 export type Theme = typeof theme;
 
-// Media Query Helpers - Reusable across all components
-// Usage: ${media.mobile} { styles... }
-export const media = {
-	// Mobile-first approach: styles apply to this size and DOWN
-	mobile: `@media (max-width: ${theme.breakpoints.mobile}px)`,
-
-	// Tablet range: between mobile and desktop
-	tablet: `@media (min-width: ${theme.breakpoints.mobile + 1}px) and (max-width: ${theme.breakpoints.tablet}px)`,
-
-	// Tablet and below (mobile + tablet)
-	tabletDown: `@media (max-width: ${theme.breakpoints.tablet}px)`,
-
-	// Desktop and up
-	desktop: `@media (min-width: ${theme.breakpoints.tablet + 1}px)`,
-
-	// Wide screens
-	wide: `@media (min-width: ${theme.breakpoints.wide}px)`,
-
-	// Hover-capable devices (prevents hover effects on touch devices)
-	hover: '@media (hover: hover) and (pointer: fine)'
-} as const;
+export { media };

--- a/src/styles/App.styles.ts
+++ b/src/styles/App.styles.ts
@@ -1,5 +1,6 @@
 // Styled components for App component
 import styled from 'styled-components';
+import { media } from './responsive';
 
 export const StyledApp = styled.div`
 	min-height: 100vh;
@@ -79,7 +80,7 @@ export const FixedAuthStatus = styled.div`
 		flex: 0 0 auto;
 	}
 
-	@media (max-width: 480px) {
+	${media.mobile} {
 		top: 0.5rem;
 		right: 0.5rem;
 		padding: 0.375rem;

--- a/src/styles/responsive.ts
+++ b/src/styles/responsive.ts
@@ -1,0 +1,15 @@
+export const breakpoints = {
+	tablet: 768,
+	desktop: 1200
+} as const;
+
+export const media = {
+	mobile: `@media (max-width: ${breakpoints.tablet - 1}px)`,
+	tabletUp: `@media (min-width: ${breakpoints.tablet}px)`,
+	tablet: `@media (min-width: ${breakpoints.tablet}px) and (max-width: ${breakpoints.desktop - 1}px)`,
+	tabletDown: `@media (max-width: ${breakpoints.desktop - 1}px)`,
+	desktop: `@media (min-width: ${breakpoints.desktop}px)`,
+	// Compatibility alias. Wide layouts now share the desktop threshold.
+	wide: `@media (min-width: ${breakpoints.desktop}px)`,
+	hover: '@media (hover: hover) and (pointer: fine)'
+} as const;


### PR DESCRIPTION
## Summary

1. Add the alternative character-sheet route and load-screen option.
2. Implement the resource, attribute, combat, defense, and tabbed-content layout iterated in local review.
3. Model natural-weapon and ancestry attack traits, including mechanical modifiers and contextual riders.
4. Reuse shared add/edit/delete row controls across tab content.
5. Align responsive behavior with the application breakpoints.

## Stack

1. Stacked on #142.
2. Merge after #142.
3. Next: system-document governance.

## Validation

1. Production build passes.
2. `git diff --check` passes.
3. 24 focused tests pass across alternative mastery/combat sections, ancestry attack traits, attack presentation, attacks, stat cards, and row editing.
4. Full unit run: 1,979 pass; the remaining snapshot/versioning assertions reproduce the failures on `main`. The stack also makes three browser copies of existing versioning assertions execute instead of reporting the existing no-suite error.